### PR TITLE
Allow user to trust filer certificate

### DIFF
--- a/ansible_collections/ctera/ctera/plugins/doc_fragments/filer.py
+++ b/ansible_collections/ctera/ctera/plugins/doc_fragments/filer.py
@@ -19,6 +19,10 @@ options:
     description: Password of the user
     required: True
     type: str
+  filer_trust_certificate:
+    description: Trust unverified certificates
+    type: bool
+    default: False
 
 requirements:
   - A physical or virtual CTERA-Networks Gateway

--- a/ansible_collections/ctera/ctera/plugins/module_utils/ctera_edge.py
+++ b/ansible_collections/ctera/ctera/plugins/module_utils/ctera_edge.py
@@ -24,7 +24,7 @@ from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 import ansible_collections.ctera.ctera.plugins.module_utils.ctera_common as ctera_common
 
 try:
-    from cterasdk import Gateway, CTERAException, tojsonstr
+    from cterasdk import Gateway, CTERAException, tojsonstr, config
 except ImportError:  # pragma: no cover
     pass  # caught by ctera_common
 
@@ -34,7 +34,8 @@ class GatewayAnsibleModule(AnsibleModule):
     default_argument_spec = {
         'filer_host': dict(type='str', required=True),
         'filer_user': dict(type='str', required=True),
-        'filer_password': dict(type='str', required=True, no_log=True)
+        'filer_password': dict(type='str', required=True, no_log=True),
+        'filer_trust_certificate': dict(type='bool', required=False, default=False)
     }
 
     def __init__(
@@ -55,6 +56,8 @@ class GatewayAnsibleModule(AnsibleModule):
                          required_if=required_if, required_by=required_by or {})
         if not ctera_common.HAS_CTERASDK:
             self.fail_json(msg=missing_required_lib('CTERASDK'), exception=ctera_common.CTERASDK_IMP_ERR)
+        if self.params['filer_trust_certificate']:
+            config.http['ssl'] = 'Trust'
         self._ctera_filer = Gateway(self.params['filer_host'])
         self._ctera_return_value = ctera_common.AnsibleReturnValue()
 

--- a/tests/ut/mocks/ansible_module_mock.py
+++ b/tests/ut/mocks/ansible_module_mock.py
@@ -1,10 +1,13 @@
+filer_trust_certificate = False
+
 class AnsibleModuleMock():
 
     def __init__(self, _argument_spec, **_kwargs):
         self.params = dict(
             filer_host='192.168.1.1',
             filer_user='admin',
-            filer_password='password'
+            filer_password='password',
+            filer_trust_certificate=filer_trust_certificate
         )
         self.fail_dict = {}
         self.exit_dict = {}

--- a/tests/ut/module_utils/test_ctera_edge.py
+++ b/tests/ut/module_utils/test_ctera_edge.py
@@ -107,3 +107,14 @@ class TestCteraEdge(BaseTest):  #pylint: disable=too-many-public-methods
         else:
             self.assertDictEqual(gateway_ansible_module.exit_dict, expected_dict)
             self.assertDictEqual(gateway_ansible_module.fail_dict, {})
+
+    def test_filer_trust_certificate_true(self):
+        self._test_filer_trust_certificate(True)
+
+    def test_filer_trust_certificate_false(self):
+        self._test_filer_trust_certificate(False)
+
+    def _test_filer_trust_certificate(self, trust):
+        ansible_module_mock.filer_trust_certificate = trust
+        ctera_edge.GatewayAnsibleModule(dict())
+        self.assertEqual(ctera_edge.config.http['ssl'], 'Trust' if trust else 'Consent')


### PR DESCRIPTION
Add an optional parameter to all filer modules called filer_trust_certificate
If True, the SDK is configured to always trust the certificate.
By default the parameter is set to False