### PR TITLE
Initial support for CTERA Portal

### DIFF
--- a/ansible_collections/ctera/ctera/README.md
+++ b/ansible_collections/ctera/ctera/README.md
@@ -42,9 +42,9 @@ To use a module from CTERA collection, please reference the full namespace, coll
       server: 192.168.68.122
       user: ygal
       password: Gr8erPassword!
-      filer_host: "{{ filer_host }}"
-      filer_user: "{{ filer_user }}"
-      filer_password: "{{ filer_password }}"
+      ctera_host: "{{ filer_host }}"
+      ctera_user: "{{ filer_user }}"
+      ctera_password: "{{ filer_password }}"
 ```
 
 Or you can add full namepsace and collection name in the `collections` element:
@@ -66,9 +66,9 @@ Or you can add full namepsace and collection name in the `collections` element:
       server: 192.168.68.122
       user: ygal
       password: Gr8erPassword!
-      filer_host: "{{ filer_host }}"
-      filer_user: "{{ filer_user }}"
-      filer_password: "{{ filer_password }}"
+      ctera_host: "{{ filer_host }}"
+      ctera_user: "{{ filer_user }}"
+      ctera_password: "{{ filer_password }}"
 ```
 
 ## License

--- a/ansible_collections/ctera/ctera/plugins/doc_fragments/ctera.py
+++ b/ansible_collections/ctera/ctera/plugins/doc_fragments/ctera.py
@@ -4,29 +4,29 @@ __metaclass__ = type
 
 
 class ModuleDocFragment(object):
-    # Documentation fragment for FILER (ctera_filer)
+    # Documentation fragment for CTERA (ctera)
     DOCUMENTATION = r'''
 options:
-  filer_host:
-    description: IP Address or FQDN of the CTERA Networks Filer
+  ctera_host:
+    description: IP Address or FQDN of the CTERA Networks Host
     required: True
     type: str
-  filer_https:
-    description: Connect to the Filer using HTTPS
+  ctera_https:
+    description: Connect to the Host using HTTPS
     type: bool
     default: True
-  filer_port:
-    description: Connection port to the Filer
+  ctera_port:
+    description: Connection port to the Host
     type: int
-  filer_user:
-    description: User Name for communicating with the CTERA Networks Filer
+  ctera_user:
+    description: User Name for communicating with the CTERA Networks Host
     required: True
     type: str
-  filer_password:
+  ctera_password:
     description: Password of the user
     required: True
     type: str
-  filer_trust_certificate:
+  ctera_trust_certificate:
     description: Trust unverified certificates
     type: bool
     default: False

--- a/ansible_collections/ctera/ctera/plugins/doc_fragments/vportal.py
+++ b/ansible_collections/ctera/ctera/plugins/doc_fragments/vportal.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+class ModuleDocFragment(object):
+    # Documentation fragment for CTERA Portal (ctera)
+    DOCUMENTATION = r'''
+extends_documentation_fragment:
+    - ctera.ctera.ctera
+options:
+  tenant:
+    description:
+    - Name of the tenant.
+    - Use default if not provided.
+    - Do not set for initialization or Global Admin operations
+    type: str
+
+'''

--- a/ansible_collections/ctera/ctera/plugins/module_utils/ctera_ansible_module.py
+++ b/ansible_collections/ctera/ctera/plugins/module_utils/ctera_ansible_module.py
@@ -1,0 +1,69 @@
+# This code is part of Ansible, but is an independent component.
+# This particular file snippet, and this file snippet only, is licensed under the Apache License 2.0.
+# Modules you write using this snippet, which is embedded dynamically by Ansible
+# still belong to the author of the module, and may assign their own license
+# to the complete work.
+#
+# Copyright 2020, CTERA Networks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+import ansible_collections.ctera.ctera.plugins.module_utils.ctera_common as ctera_common
+
+try:
+    from cterasdk import CTERAException, tojsonstr, config
+except ImportError:  # pragma: no cover
+    pass  # caught by ctera_common
+
+
+class CteraAnsibleModule(AnsibleModule):
+
+    default_argument_spec = {
+        'ctera_host': dict(type='str', required=True),
+        'ctera_https': dict(type='bool', required=False, default=True),
+        'ctera_port': dict(type='int', required=False),
+        'ctera_user': dict(type='str', required=True),
+        'ctera_password': dict(type='str', required=True, no_log=True),
+        'ctera_trust_certificate': dict(type='bool', required=False, default=False)
+    }
+
+    def __init__(self, argument_spec, **kwargs):
+        argument_spec.update(CteraAnsibleModule.default_argument_spec)
+        super().__init__(argument_spec, **kwargs)
+        if not ctera_common.HAS_CTERASDK:
+            self.fail_json(msg=missing_required_lib('CTERASDK'), exception=ctera_common.CTERASDK_IMP_ERR)
+        config.http['ssl'] = 'Trust' if self.params['ctera_trust_certificate'] else 'Consent'
+        self._ctera_return_value = ctera_common.AnsibleReturnValue()
+        self._ctera_host = None
+
+    def ctera_login(self):
+        try:
+            self._ctera_host.login(self.params['ctera_user'], self.params['ctera_password'])
+        except CTERAException as error:
+            self._ctera_return_value.failed().msg('Login failed. Exception: %s' % tojsonstr(error, False))
+            self.ctera_exit()
+
+    def ctera_logout(self):
+        self._ctera_host.logout()
+
+    def ctera_return_value(self):
+        return self._ctera_return_value
+
+    def ctera_exit(self):
+        if self._ctera_return_value.has_failed():
+            self.fail_json(**self._ctera_return_value.as_dict())
+        else:
+            self.exit_json(**self._ctera_return_value.as_dict())

--- a/ansible_collections/ctera/ctera/plugins/module_utils/ctera_filer_base.py
+++ b/ansible_collections/ctera/ctera/plugins/module_utils/ctera_filer_base.py
@@ -21,40 +21,22 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible_collections.ctera.ctera.plugins.module_utils.ctera_edge import GatewayAnsibleModule
-import ansible_collections.ctera.ctera.plugins.module_utils.ctera_common as ctera_common
-
-try:
-    from cterasdk import CTERAException, tojsonstr
-except ImportError:  # pragma: no cover
-    pass  # caught by ctera_common
+from ansible_collections.ctera.ctera.plugins.module_utils.ctera_runner_base import CteraRunnerBase
 
 
-class CteraFilerBase(object):
+class CteraFilerBase(CteraRunnerBase):
 
     def __init__(self, ansible_module_args, supports_check_mode=False, required_if=None, login=True, required_by=None):
-        required_if = required_if or []
-        self.ansible_module = GatewayAnsibleModule(
+        super().__init__(
+            GatewayAnsibleModule,
             ansible_module_args,
             supports_check_mode=supports_check_mode,
             required_if=required_if,
+            login=login,
             required_by=required_by
         )
-        self.parameters = ctera_common.get_parameters(self.ansible_module.params)
         self._ctera_filer = None
-        self._login = login
 
     def run(self):
         self._ctera_filer = self.ansible_module.ctera_filer(login=self._login)
-        try:
-            self._execute()
-        except CTERAException as error:
-            self.ansible_module.ctera_return_value().failed().msg(self._generic_failure_message + (' Exception: %s' % tojsonstr(error, False)))
-        self.ansible_module.ctera_logout()
-        self.ansible_module.ctera_exit()
-
-    @property
-    def _generic_failure_message(self):  # pragma: no cover
-        raise NotImplementedError("Implementing classes must implemen _generic_failure_message")
-
-    def _execute(self):  # pragma: no cover
-        raise NotImplementedError("Implementing classes must implemen _execute")
+        super().run()

--- a/ansible_collections/ctera/ctera/plugins/module_utils/ctera_portal.py
+++ b/ansible_collections/ctera/ctera/plugins/module_utils/ctera_portal.py
@@ -23,18 +23,22 @@ __metaclass__ = type
 from ansible_collections.ctera.ctera.plugins.module_utils.ctera_ansible_module import CteraAnsibleModule
 
 try:
-    from cterasdk import Gateway
+    from cterasdk import GlobalAdmin
 except ImportError:  # pragma: no cover
     pass  # caught by ctera_common
 
 
-class GatewayAnsibleModule(CteraAnsibleModule):
+class PortalAnsibleModule(CteraAnsibleModule):
+    default_argument_spec = {
+        'tenant': dict(type='str')
+    }
 
     def __init__(self, argument_spec, **kwargs):
+        argument_spec.update(PortalAnsibleModule.default_argument_spec)
         super().__init__(argument_spec, **kwargs)
-        self._ctera_host = Gateway(self.params['ctera_host'], port=self.params['ctera_port'], https=self.params['ctera_https'])
+        self._ctera_host = GlobalAdmin(self.params['ctera_host'], port=self.params['ctera_port'], https=self.params['ctera_https'])
 
-    def ctera_filer(self, login=True):
+    def ctera_portal(self, login=True):
         if login:
             self.ctera_login()
         return self._ctera_host

--- a/ansible_collections/ctera/ctera/plugins/module_utils/ctera_runner_base.py
+++ b/ansible_collections/ctera/ctera/plugins/module_utils/ctera_runner_base.py
@@ -1,0 +1,59 @@
+# This code is part of Ansible, but is an independent component.
+# This particular file snippet, and this file snippet only, is licensed under the Apache License 2.0.
+# Modules you write using this snippet, which is embedded dynamically by Ansible
+# still belong to the author of the module, and may assign their own license
+# to the complete work.
+#
+# Copyright 2020, CTERA Networks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from abc import ABC, abstractmethod, abstractproperty
+
+import ansible_collections.ctera.ctera.plugins.module_utils.ctera_common as ctera_common
+
+try:
+    from cterasdk import CTERAException, tojsonstr
+except ImportError:  # pragma: no cover
+    pass  # caught by ctera_common
+
+
+class CteraRunnerBase(ABC):
+
+    def __init__(self, ansible_module_class, ansible_module_args, login=True, supports_check_mode=False, required_if=None, required_by=None):
+        self.ansible_module = ansible_module_class(
+            ansible_module_args,
+            supports_check_mode=supports_check_mode,
+            required_if=required_if or [],
+            required_by=required_by or {}
+        )
+        self.parameters = ctera_common.get_parameters(self.ansible_module.params)
+        self._login = login
+
+    def run(self):
+        try:
+            self._execute()
+        except CTERAException as error:
+            self.ansible_module.ctera_return_value().failed().msg(self._generic_failure_message + (' Exception: %s' % tojsonstr(error, False)))
+        self.ansible_module.ctera_logout()
+        self.ansible_module.ctera_exit()
+
+    @abstractproperty
+    def _generic_failure_message(self):  # pragma: no cover
+        raise NotImplementedError("Implementing classes must implement _generic_failure_message")
+
+    @abstractmethod
+    def _execute(self):  # pragma: no cover
+        raise NotImplementedError("Implementing classes must implement _execute")

--- a/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_async_io.py
+++ b/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_async_io.py
@@ -19,9 +19,8 @@ module: ctera_filer_async_io
 short_description: CTERA-Networks Filer Async-I/O configuration and management
 description:
     - Enable or Disable Async-I/O.
-version_added: "2.10"
 extends_documentation_fragment:
-    - ctera.ctera.filer
+    - ctera.ctera.ctera
 
 author:
     - Saimon Michelson (@saimonation)
@@ -38,16 +37,16 @@ options:
 EXAMPLES = '''
 - name: Enable Async-I/O
   ctera_filer_async_io:
-    filer_host: "{{ ctera_filer_hostname }}"
-    filer_user: "{{ ctera_filer_user }}"
-    filer_password: "{{ ctera_filer_password }}"
+    ctera_host: "{{ ctera_filer_hostname }}"
+    ctera_user: "{{ ctera_filer_user }}"
+    ctera_password: "{{ ctera_filer_password }}"
 
 - name: Disable Async-I/O
   ctera_filer_async_io:
     enabled: False
-    filer_host: "{{ ctera_filer_hostname }}"
-    filer_user: "{{ ctera_filer_user }}"
-    filer_password: "{{ ctera_filer_password }}"
+    ctera_host: "{{ ctera_filer_hostname }}"
+    ctera_user: "{{ ctera_filer_user }}"
+    ctera_password: "{{ ctera_filer_password }}"
 '''
 
 RETURN = r''' # '''

--- a/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_backup.py
+++ b/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_backup.py
@@ -19,9 +19,8 @@ module: ctera_filer_backup
 short_description: Configure backup settings for a CTERA-Networks filer. Currently, you cannot modify or disable the configuration
 description:
     - Configure backup settings for a CTERA-Networks filer
-version_added: "2.10"
 extends_documentation_fragment:
-    - ctera.ctera.filer
+    - ctera.ctera.ctera
 
 author:
     - Saimon Michelson (@saimonation)

--- a/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_cloud_cache.py
+++ b/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_cloud_cache.py
@@ -20,9 +20,8 @@ short_description: CTERA-Networks Filer Cloud Sync configuration and management
 description:
     - Enable or Disable Cloud-Sync
     - Refresh folders
-version_added: "2.10"
 extends_documentation_fragment:
-    - ctera.ctera.filer
+    - ctera.ctera.ctera
 
 author:
     - Saimon Michelson (@saimonation)
@@ -54,30 +53,30 @@ options:
 EXAMPLES = '''
 - name: Enable Caching Gateway and start sync w/o refresh
   ctera_filer_cloud_cache:
-    filer_host: "{{ ctera_filer_hostname }}"
-    filer_user: "{{ ctera_filer_user }}"
-    filer_password: "{{ ctera_filer_password }}"
+    ctera_host: "{{ ctera_filer_hostname }}"
+    ctera_user: "{{ ctera_filer_user }}"
+    ctera_password: "{{ ctera_filer_password }}"
 
 - name: Enable Caching Gateway and start sync with refresh
   ctera_filer_cloud_cache:
     refresh_folders: True
-    filer_host: "{{ ctera_filer_hostname }}"
-    filer_user: "{{ ctera_filer_user }}"
-    filer_password: "{{ ctera_filer_password }}"
+    ctera_host: "{{ ctera_filer_hostname }}"
+    ctera_user: "{{ ctera_filer_user }}"
+    ctera_password: "{{ ctera_filer_password }}"
 
 - name: Enable Caching Gateway w/o sync
   ctera_filer_cloud_cache:
     sync_enabled: False
-    filer_host: "{{ ctera_filer_hostname }}"
-    filer_user: "{{ ctera_filer_user }}"
-    filer_password: "{{ ctera_filer_password }}"
+    ctera_host: "{{ ctera_filer_hostname }}"
+    ctera_user: "{{ ctera_filer_user }}"
+    ctera_password: "{{ ctera_filer_password }}"
 
 - name: Disable Caching Gateway
   ctera_filer_cloud_cache:
     enabled: False
-    filer_host: "{{ ctera_filer_hostname }}"
-    filer_user: "{{ ctera_filer_user }}"
-    filer_password: "{{ ctera_filer_password }}"
+    ctera_host: "{{ ctera_filer_hostname }}"
+    ctera_user: "{{ ctera_filer_user }}"
+    ctera_password: "{{ ctera_filer_password }}"
 '''
 
 RETURN = r''' # '''

--- a/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_cloud_services.py
+++ b/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_cloud_services.py
@@ -19,9 +19,8 @@ module: ctera_filer_cloud_services
 short_description: Cloud services configuration and management
 description:
     - Connect, Disconnect and Reconnect a CTERA filer to the cloud serivces
-version_added: "2.10"
 extends_documentation_fragment:
-    - ctera.ctera.filer
+    - ctera.ctera.ctera
 
 author:
     - Saimon Michelson (@saimonation)
@@ -82,9 +81,9 @@ EXAMPLES = '''
     user: admin
     password: admin
     ctera_license: EV32
-    filer_host: "{{ ctera_filer_hostname }}"
-    filer_user: "{{ ctera_filer_user }}"
-    filer_password: "{{ ctera_filer_password }}"
+    ctera_host: "{{ ctera_filer_hostname }}"
+    ctera_user: "{{ ctera_filer_user }}"
+    ctera_password: "{{ ctera_filer_password }}"
 '''
 
 RETURN = '''

--- a/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_device_reboot.py
+++ b/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_device_reboot.py
@@ -19,9 +19,8 @@ module: ctera_filer_device_reboot
 short_description: Reboot the CTERA-Networks filer
 description:
     - Reboot the CTERA-Networks filer
-version_added: "2.10"
 extends_documentation_fragment:
-    - ctera.ctera.filer
+    - ctera.ctera.ctera
 
 author:
     - Saimon Michelson (@saimonation)
@@ -41,9 +40,9 @@ requirements:
 EXAMPLES = '''
 - name: Reboot
   ctera_filer_device_reboot:
-    filer_host: "{{ ctera_filer_hostname }}"
-    filer_user: "{{ ctera_filer_user }}"
-    filer_password: "{{ ctera_filer_password }}"
+    ctera_host: "{{ ctera_filer_hostname }}"
+    ctera_user: "{{ ctera_filer_user }}"
+    ctera_password: "{{ ctera_filer_password }}"
 '''
 
 RETURN = r''' # '''

--- a/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_device_reset.py
+++ b/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_device_reset.py
@@ -19,9 +19,8 @@ module: ctera_filer_device_reset
 short_description: Reset the CTERA-Networks filer to factory settings
 description:
     - Reset the CTERA-Networks filer to factory settings
-version_added: "2.10"
 extends_documentation_fragment:
-    - ctera.ctera.filer
+    - ctera.ctera.ctera
 
 author:
     - Saimon Michelson (@saimonation)
@@ -41,9 +40,9 @@ requirements:
 EXAMPLES = '''
 - name: Reset to factory settings
   ctera_filer_device_reset:
-    filer_host: "{{ ctera_filer_hostname }}"
-    filer_user: "{{ ctera_filer_user }}"
-    filer_password: "{{ ctera_filer_password }}"
+    ctera_host: "{{ ctera_filer_hostname }}"
+    ctera_user: "{{ ctera_filer_user }}"
+    ctera_password: "{{ ctera_filer_password }}"
 '''
 
 RETURN = r''' # '''

--- a/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_directory_services.py
+++ b/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_directory_services.py
@@ -20,9 +20,8 @@ short_description: CTERA-Networks Filer active directory configuration and manag
 description:
     - Connect, Disconnect and Reconnect a CTERA-Networks filer to active directory
     - If you only need to change the username and or password, set force_connect to True
-version_added: "2.10"
 extends_documentation_fragment:
-    - ctera.ctera.filer
+    - ctera.ctera.ctera
 
 author:
     - Saimon Michelson (@saimonation)
@@ -63,16 +62,16 @@ EXAMPLES = '''
     host: www.example.com
     user: admin
     pass: admin
-    filer_host: "{{ ctera_filer_hostname }}"
-    filer_user: "{{ ctera_filer_user }}"
-    filer_password: "{{ ctera_filer_password }}"
+    ctera_host: "{{ ctera_filer_hostname }}"
+    ctera_user: "{{ ctera_filer_user }}"
+    ctera_password: "{{ ctera_filer_password }}"
 
 - name: Directory Services - Disonnected
   ctera_filer_directory_services:
     state: disconnected
-    filer_host: "{{ ctera_filer_hostname }}"
-    filer_user: "{{ ctera_filer_user }}"
-    filer_password: "{{ ctera_filer_password }}"
+    ctera_host: "{{ ctera_filer_hostname }}"
+    ctera_user: "{{ ctera_filer_user }}"
+    ctera_password: "{{ ctera_filer_password }}"
 '''
 
 RETURN = '''

--- a/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_first_user.py
+++ b/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_first_user.py
@@ -20,9 +20,8 @@ short_description: First user on a CTERA-Networks filer
 description:
     - First user on a CTERA-Networks filer
     - Please note that the first user cannot be modified.
-version_added: "2.10"
 extends_documentation_fragment:
-    - ctera.ctera.filer
+    - ctera.ctera.ctera
 
 author:
     - Saimon Michelson (@saimonation)
@@ -40,9 +39,9 @@ requirements:
 EXAMPLES = '''
 - name: first local user
   ctera_filer_add_first_user:
-    filer_host: "{{ ctera_filer_hostname }}"
-    filer_user: "{{ ctera_filer_user }}"
-    filer_password: "{{ ctera_filer_password }}"
+    ctera_host: "{{ ctera_filer_hostname }}"
+    ctera_user: "{{ ctera_filer_user }}"
+    ctera_password: "{{ ctera_filer_password }}"
 '''
 
 RETURN = '''
@@ -68,12 +67,12 @@ class CteraFilerFirstUser(CteraFilerBase):
         logininfo = self._ctera_filer.get('/nosession/logininfo')
 
         if logininfo.isfirstlogin:
-            self._ctera_filer.users.add_first_user(self.parameters['filer_user'], self.parameters['filer_password'], email=self.parameters.get('email', ''))
+            self._ctera_filer.users.add_first_user(self.parameters['ctera_user'], self.parameters['ctera_password'], email=self.parameters.get('email', ''))
             self.ansible_module.ctera_return_value().changed().msg('User created')
         else:
             self._ctera_filer = self.ansible_module.ctera_filer(login=True)
             self.ansible_module.ctera_return_value().msg('First user was already created')
-        self.ansible_module.ctera_return_value().put(user=self.parameters['filer_user'])
+        self.ansible_module.ctera_return_value().put(user=self.parameters['ctera_user'])
 
 
 def main():  # pragma: no cover

--- a/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_ftp.py
+++ b/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_ftp.py
@@ -19,9 +19,8 @@ module: ctera_filer_ftp
 short_description: Manage the FTP configuration of the CTERA-Networks filer
 description:
     - Enable/Disable/Modify the FTP configuration of the CTERA-Networks filer
-version_added: "2.10"
 extends_documentation_fragment:
-    - ctera.ctera.filer
+    - ctera.ctera.ctera
 
 author:
     - Saimon Michelson (@saimonation)
@@ -62,9 +61,9 @@ requirements:
 EXAMPLES = '''
 - name: Configure FTP as default
   ctera_filer_ftp:
-    filer_host: "{{ ctera_filer_hostname }}"
-    filer_user: "{{ ctera_filer_user }}"
-    filer_password: "{{ ctera_filer_password }}"
+    ctera_host: "{{ ctera_filer_hostname }}"
+    ctera_user: "{{ ctera_filer_user }}"
+    ctera_password: "{{ ctera_filer_password }}"
 '''
 
 RETURN = r''' # '''

--- a/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_hostname.py
+++ b/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_hostname.py
@@ -19,9 +19,8 @@ module: ctera_filer_hostname
 short_description: Set the hostname of  the CTERA-Networks filer
 description:
     - Set the hostname of  the CTERA-Networks filer
-version_added: "2.10"
 extends_documentation_fragment:
-    - ctera.ctera.filer
+    - ctera.ctera.ctera
 
 author:
     - Saimon Michelson (@saimonation)
@@ -41,9 +40,9 @@ EXAMPLES = '''
 - name: Set Hostname
   ctera_filer_hostname:
     hostname: Example
-    filer_host: "{{ ctera_filer_hostname }}"
-    filer_user: "{{ ctera_filer_user }}"
-    filer_password: "{{ ctera_filer_password }}"
+    ctera_host: "{{ ctera_filer_hostname }}"
+    ctera_user: "{{ ctera_filer_user }}"
+    ctera_password: "{{ ctera_filer_password }}"
 '''
 
 RETURN = '''

--- a/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_license.py
+++ b/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_license.py
@@ -19,9 +19,8 @@ module: ctera_filer_license
 short_description: Apply a license on a CTERA-Networks filer
 description:
     - Apply a license on a CTERA-Networks filer
-version_added: "2.10"
 extends_documentation_fragment:
-    - ctera.ctera.filer
+    - ctera.ctera.ctera
 
 author:
     - Saimon Michelson (@saimonation)
@@ -47,9 +46,9 @@ EXAMPLES = '''
 - name: apply license
   ctera_filer_apply_license:
     license: EV16
-    filer_host: "{{ ctera_filer_hostname }}"
-    filer_user: "{{ ctera_filer_user }}"
-    filer_password: "{{ ctera_filer_password }}"
+    ctera_host: "{{ ctera_filer_hostname }}"
+    ctera_user: "{{ ctera_filer_user }}"
+    ctera_password: "{{ ctera_filer_password }}"
 '''
 
 RETURN = '''

--- a/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_location.py
+++ b/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_location.py
@@ -19,9 +19,8 @@ module: ctera_filer_location
 short_description: Set the location of the CTERA-Networks filer
 description:
     - Set the location of the CTERA-Networks filer
-version_added: "2.10"
 extends_documentation_fragment:
-    - ctera.ctera.filer
+    - ctera.ctera.ctera
 
 author:
     - Saimon Michelson (@saimonation)
@@ -41,9 +40,9 @@ EXAMPLES = '''
 - name: Set Location
   ctera_filer_location:
     location: Somewhere
-    filer_host: "{{ ctera_filer_hostname }}"
-    filer_user: "{{ ctera_filer_user }}"
-    filer_password: "{{ ctera_filer_password }}"
+    ctera_host: "{{ ctera_filer_hostname }}"
+    ctera_user: "{{ ctera_filer_user }}"
+    ctera_password: "{{ ctera_filer_password }}"
 '''
 
 RETURN = '''

--- a/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_network.py
+++ b/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_network.py
@@ -19,9 +19,8 @@ module: ctera_filer_network
 short_description: CTERA-Networks filer network configuration
 description:
     - Configure the network of a CTERA-Networks filer
-version_added: "2.10"
 extends_documentation_fragment:
-    - ctera.ctera.filer
+    - ctera.ctera.ctera
 
 author:
     - Saimon Michelson (@saimonation)
@@ -58,16 +57,16 @@ requirements:
 EXAMPLES = '''
 - name: Use DHCP
   ctera_filer_network:
-    filer_host: "{{ ctera_filer_hostname }}"
-    filer_user: "{{ ctera_filer_user }}"
-    filer_password: "{{ ctera_filer_password }}"
+    ctera_host: "{{ ctera_filer_hostname }}"
+    ctera_user: "{{ ctera_filer_user }}"
+    ctera_password: "{{ ctera_filer_password }}"
 
 - name: Set DNS Server
   ctera_filer_network:
     primary_dns_server: 8.8.8.8
-    filer_host: "{{ ctera_filer_hostname }}"
-    filer_user: "{{ ctera_filer_user }}"
-    filer_password: "{{ ctera_filer_password }}"
+    ctera_host: "{{ ctera_filer_hostname }}"
+    ctera_user: "{{ ctera_filer_user }}"
+    ctera_password: "{{ ctera_filer_password }}"
 
 - name: Set IP Address
   ctera_filer_network:
@@ -75,9 +74,9 @@ EXAMPLES = '''
     subnet: 255.255.255.0
     gateway: 192.168.1.1
     primary_dns_server: 8.8.8.8
-    filer_host: "{{ ctera_filer_hostname }}"
-    filer_user: "{{ ctera_filer_user }}"
-    filer_password: "{{ ctera_filer_password }}"
+    ctera_host: "{{ ctera_filer_hostname }}"
+    ctera_user: "{{ ctera_filer_user }}"
+    ctera_password: "{{ ctera_filer_password }}"
 '''
 
 RETURN = r''' # '''

--- a/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_nfs.py
+++ b/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_nfs.py
@@ -19,9 +19,8 @@ module: ctera_filer_nfs
 short_description: Manage the NFS configuration of the CTERA-Networks filer
 description:
     - Enable/Disable/Modify the NFS configuration of the CTERA-Networks filer
-version_added: "2.10"
 extends_documentation_fragment:
-    - ctera.ctera.filer
+    - ctera.ctera.ctera
 
 author:
     - Saimon Michelson (@saimonation)
@@ -48,9 +47,9 @@ requirements:
 EXAMPLES = '''
 - name: Configure NFS as default
   ctera_filer_nfs:
-    filer_host: "{{ ctera_filer_hostname }}"
-    filer_user: "{{ ctera_filer_user }}"
-    filer_password: "{{ ctera_filer_password }}"
+    ctera_host: "{{ ctera_filer_hostname }}"
+    ctera_user: "{{ ctera_filer_user }}"
+    ctera_password: "{{ ctera_filer_password }}"
 '''
 
 RETURN = r''' # '''

--- a/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_rsync.py
+++ b/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_rsync.py
@@ -19,9 +19,8 @@ module: ctera_filer_rsync
 short_description: Manage the RSync configuration of the CTERA-Networks filer
 description:
     - Enable/Disable/Modify the RSync configuration of the CTERA-Networks filer
-version_added: "2.10"
 extends_documentation_fragment:
-    - ctera.ctera.filer
+    - ctera.ctera.ctera
 
 author:
     - Saimon Michelson (@saimonation)
@@ -47,9 +46,9 @@ requirements:
 EXAMPLES = '''
 - name: Configure RSync as default
   ctera_filer_rsync:
-    filer_host: "{{ ctera_filer_hostname }}"
-    filer_user: "{{ ctera_filer_user }}"
-    filer_password: "{{ ctera_filer_password }}"
+    ctera_host: "{{ ctera_filer_hostname }}"
+    ctera_user: "{{ ctera_filer_user }}"
+    ctera_password: "{{ ctera_filer_password }}"
 '''
 
 RETURN = r''' # '''

--- a/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_share.py
+++ b/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_share.py
@@ -20,9 +20,8 @@ short_description: CTERA Filer share configuration and management
 description:
     - Create, modify and delete shares.
     - This module does not handle the creation of the directory and share creation will fail if the directory does not exist
-version_added: "2.10"
 extends_documentation_fragment:
-    - ctera.ctera.filer
+    - ctera.ctera.ctera
 
 author:
     - Saimon Michelson (@saimonation)
@@ -47,6 +46,7 @@ options:
   acl:
     description: List of Access Control Entries
     type: list
+    elements: dict
     suboptions:
       principal_type:
         description: The principal type
@@ -127,9 +127,9 @@ EXAMPLES = '''
       type: LocalGroup
       perm: ReadWrite
     access: authenticated
-    filer_host: "{{ ctera_filer_hostname }}"
-    filer_user: "{{ ctera_filer_user }}"
-    filer_password: "{{ ctera_filer_password }}"
+    ctera_host: "{{ ctera_filer_hostname }}"
+    ctera_user: "{{ ctera_filer_user }}"
+    ctera_password: "{{ ctera_filer_password }}"
 '''
 
 RETURN = '''

--- a/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_smb.py
+++ b/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_smb.py
@@ -19,9 +19,8 @@ module: ctera_filer_smb
 short_description: Manage the SMB configuration of the CTERA-Networks filer
 description:
     - Enable/Disable/Modify the SMB configuration of the CTERA-Networks filer
-version_added: "2.10"
 extends_documentation_fragment:
-    - ctera.ctera.filer
+    - ctera.ctera.ctera
 
 author:
     - Saimon Michelson (@saimonation)
@@ -64,9 +63,9 @@ requirements:
 EXAMPLES = '''
 - name: Configure SMB as default
   ctera_filer_smb:
-    filer_host: "{{ ctera_filer_hostname }}"
-    filer_user: "{{ ctera_filer_user }}"
-    filer_password: "{{ ctera_filer_password }}"
+    ctera_host: "{{ ctera_filer_hostname }}"
+    ctera_user: "{{ ctera_filer_user }}"
+    ctera_password: "{{ ctera_filer_password }}"
 '''
 
 RETURN = r''' # '''

--- a/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_syslog.py
+++ b/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_syslog.py
@@ -19,9 +19,8 @@ module: ctera_filer_syslog
 short_description: Manage the Syslog configuration of the CTERA-Networks filer
 description:
     - Enable/Disable/Modify the Syslog configuration of the CTERA-Networks filer
-version_added: "2.10"
 extends_documentation_fragment:
-    - ctera.ctera.filer
+    - ctera.ctera.ctera
 
 author:
     - Saimon Michelson (@saimonation)
@@ -69,9 +68,9 @@ EXAMPLES = '''
 - name: Configure Syslog
   ctera_filer_syslog:
     server: www.example.com
-    filer_host: "{{ ctera_filer_hostname }}"
-    filer_user: "{{ ctera_filer_user }}"
-    filer_password: "{{ ctera_filer_password }}"
+    ctera_host: "{{ ctera_filer_hostname }}"
+    ctera_user: "{{ ctera_filer_user }}"
+    ctera_password: "{{ ctera_filer_password }}"
 '''
 
 RETURN = '''

--- a/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_telnet.py
+++ b/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_telnet.py
@@ -19,9 +19,8 @@ module: ctera_filer_telnet
 short_description: CTERA-Networks Filer Telnet configuration and management
 description:
     - Enable or Disable Telnet.
-version_added: "2.10"
 extends_documentation_fragment:
-    - ctera.ctera.filer
+    - ctera.ctera.ctera
 
 author:
     - Saimon Michelson (@saimonation)
@@ -43,16 +42,16 @@ EXAMPLES = '''
 - name: Enable Telnet
   ctera_filer_telnet:
     code: abcdefgh
-    filer_host: "{{ ctera_filer_hostname }}"
-    filer_user: "{{ ctera_filer_user }}"
-    filer_password: "{{ ctera_filer_password }}"
+    ctera_host: "{{ ctera_filer_hostname }}"
+    ctera_user: "{{ ctera_filer_user }}"
+    ctera_password: "{{ ctera_filer_password }}"
 
 - name: Disable Telnet
   ctera_filer_telnet:
     enabled: False
-    filer_host: "{{ ctera_filer_hostname }}"
-    filer_user: "{{ ctera_filer_user }}"
-    filer_password: "{{ ctera_filer_password }}"
+    ctera_host: "{{ ctera_filer_hostname }}"
+    ctera_user: "{{ ctera_filer_user }}"
+    ctera_password: "{{ ctera_filer_password }}"
 '''
 
 RETURN = r''' # '''

--- a/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_timezone.py
+++ b/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_timezone.py
@@ -19,9 +19,8 @@ module: ctera_filer_timezone
 short_description: Set the timezone of  the CTERA-Networks filer
 description:
     - Set the timezone of  the CTERA-Networks filer
-version_added: "2.10"
 extends_documentation_fragment:
-    - ctera.ctera.filer
+    - ctera.ctera.ctera
 
 author:
     - Saimon Michelson (@saimonation)
@@ -41,9 +40,9 @@ EXAMPLES = '''
 - name: Set Timezone
   ctera_filer_timezone:
     timezone: "(GMT-05:00) Eastern Time (US , Canada)"
-    filer_host: "{{ ctera_filer_hostname }}"
-    filer_user: "{{ ctera_filer_user }}"
-    filer_password: "{{ ctera_filer_password }}"
+    ctera_host: "{{ ctera_filer_hostname }}"
+    ctera_user: "{{ ctera_filer_user }}"
+    ctera_password: "{{ ctera_filer_password }}"
 '''
 
 RETURN = '''

--- a/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_user.py
+++ b/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_user.py
@@ -19,9 +19,8 @@ module: ctera_filer_user
 short_description: CTERA-Networks Filer user configuration and management
 description:
     - Create, modify and delete users.
-version_added: "2.10"
 extends_documentation_fragment:
-    - ctera.ctera.filer
+    - ctera.ctera.ctera
 
 author:
     - Saimon Michelson (@saimonation)
@@ -62,9 +61,9 @@ EXAMPLES = '''
     email: 'walice@wonderland.com'
     full_name: 'Alice Wonderland'
     password: 'su@p3rsecret!!'
-    filer_host: "{{ ctera_filer_hostname }}"
-    filer_user: "{{ ctera_filer_user }}"
-    filer_password: "{{ ctera_filer_password }}"
+    ctera_host: "{{ ctera_filer_hostname }}"
+    ctera_user: "{{ ctera_filer_user }}"
+    ctera_password: "{{ ctera_filer_password }}"
 '''
 
 RETURN = '''

--- a/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_volume.py
+++ b/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_volume.py
@@ -19,9 +19,8 @@ module: ctera_filer_volume
 short_description: CTERA-Networks Filer volume configuration and management
 description:
     - Create, modify and delete volumes.
-version_added: "2.10"
 extends_documentation_fragment:
-    - ctera.ctera.filer
+    - ctera.ctera.ctera
 
 author:
     - Saimon Michelson (@saimonation)
@@ -63,9 +62,9 @@ EXAMPLES = '''
 - name: create new volume
   ctera_filer_volume:
     name: main
-    filer_host: "{{ ctera_filer_hostname }}"
-    filer_user: "{{ ctera_filer_user }}"
-    filer_password: "{{ ctera_filer_password }}"
+    ctera_host: "{{ ctera_filer_hostname }}"
+    ctera_user: "{{ ctera_filer_user }}"
+    ctera_password: "{{ ctera_filer_password }}"
 '''
 
 RETURN = '''

--- a/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_wizard.py
+++ b/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_wizard.py
@@ -19,9 +19,8 @@ module: ctera_filer_wizard
 short_description: CTERA-Networks Filer First Time Wizard configuration and management
 description:
     - Enable or Disable First Time Wizard.
-version_added: "2.10"
 extends_documentation_fragment:
-    - ctera.ctera.filer
+    - ctera.ctera.ctera
 
 author:
     - Saimon Michelson (@saimonation)
@@ -39,9 +38,9 @@ EXAMPLES = '''
 - name: Disable First Time Wizard
   ctera_filer_wizard:
     enabled: False
-    filer_host: "{{ ctera_filer_hostname }}"
-    filer_user: "{{ ctera_filer_user }}"
-    filer_password: "{{ ctera_filer_password }}"
+    ctera_host: "{{ ctera_filer_hostname }}"
+    ctera_user: "{{ ctera_filer_user }}"
+    ctera_password: "{{ ctera_filer_password }}"
 '''
 
 RETURN = r''' # '''

--- a/ansible_collections/ctera/ctera/plugins/modules/ctera_portal_cloud_folder.py
+++ b/ansible_collections/ctera/ctera/plugins/modules/ctera_portal_cloud_folder.py
@@ -1,0 +1,172 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2020, CTERA Networks Ltd.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: ctera_portal_cloud_folder
+short_description: CTERA-Networks Portal cloud folder configuration and management
+description:
+    - Create, and delete cloud folders.
+extends_documentation_fragment:
+    - ctera.ctera.vportal
+
+author:
+    - Saimon Michelson (@saimonation)
+    - Ygal Blum (@ygalblum)
+
+options:
+  state:
+    description:
+    - Whether the specified user should exist or not.
+    type: str
+    choices: ['present', 'absent']
+    default: 'present'
+  name:
+    description: The name of the cloud folder
+    required: True
+    type: str
+  group:
+    description: The folder group to which the cloud folder belongs
+    type: str
+  owner:
+    description: The cloud folder owner
+    type: dict
+    required: True
+    suboptions:
+      name:
+        description: The user name
+        required: True
+        type: str
+      directory:
+        description: The fully-qualified name of the user directory, if the user belongs to one
+        type: str
+  winacls:
+    description: Use Windows ACLs
+    type: bool
+    default: True
+
+'''
+
+EXAMPLES = '''
+- name: Cloud Folder
+  ctera_portal_cloud_folder:
+    name: "AliceFiles"
+    group: "CompanyMain"
+    owner:
+      name: "Alice"
+    ctera_host: "{{ ctera_portal_hostname }}"
+    ctera_user: "{{ ctera_portal_user }}"
+    ctera_password: "{{ ctera_portal_password }}"
+
+'''
+
+RETURN = '''
+name:
+  description: Name of the cloud folder
+  returned: when state is present
+  type: str
+  sample: CompanyMain
+'''
+
+from ansible_collections.ctera.ctera.plugins.module_utils.ctera_portal_base import CteraPortalBase
+
+try:
+    from cterasdk import CTERAException, portal_types
+except ImportError:  # pragma: no cover
+    pass  # caught by ctera_common
+
+
+class CteraPortalCloudFolder(CteraPortalBase):
+    def __init__(self):
+        super().__init__(
+            dict(
+                state=dict(required=False, choices=['present', 'absent'], default='present'),
+                name=dict(type='str', required=True),
+                group=dict(type='str'),
+                owner=dict(
+                    type='dict',
+                    required=True,
+                    options=dict(
+                        name=dict(type='str', required=True),
+                        directory=dict(type='str')
+                    )
+                ),
+                winacls=dict(type='bool', default=True)
+            ),
+            required_if=[('state', 'present', ['group', 'winacls'])]
+        )
+
+    @property
+    def _generic_failure_message(self):  # pragma: no cover
+        return 'Cloud Folder management failed'
+
+    def _execute(self):
+        state = self.parameters.pop('state')
+        cloud_folder = self._get_cloud_folder()
+        if state == 'present':
+            self._ensure_present(cloud_folder)
+        else:
+            self._ensure_absent(cloud_folder)
+
+    def _get_cloud_folder(self):
+        cloud_folder = None
+        try:
+            cloud_folder = self._ctera_portal.cloudfs.find(
+                self.parameters['name'],
+                self.parameters['owner']['name'],
+                ['name', 'group', 'owner']
+            )
+        except CTERAException:
+            pass
+        return self._to_cloud_folder_dict(cloud_folder) if cloud_folder else None
+
+    @staticmethod
+    def _to_cloud_folder_dict(cloud_folder):
+        return dict(
+            name=cloud_folder.name,
+            group=cloud_folder.group.split('/')[-1],
+            owner=dict(name=cloud_folder.owner.split('/')[-1])
+        )
+
+    def _ensure_present(self, cloud_folder):
+        if cloud_folder:
+            self.ansible_module.ctera_return_value().skipped().msg('Cloud Folder already exists').put(name=self.parameters['name'])
+        else:
+            self._ctera_portal.cloudfs.mkdir(
+                self.parameters['name'],
+                self.parameters['group'],
+                self._make_user_account(self.parameters['owner']),
+                winacls=self.parameters['winacls']
+            )
+            self.ansible_module.ctera_return_value().changed().msg('Cloud Folder created').put(name=self.parameters['name'])
+
+    def _ensure_absent(self, cloud_folder):
+        if cloud_folder:
+            self._ctera_portal.cloudfs.delete(self.parameters['name'], self._make_user_account(self.parameters['owner']))
+            self.ansible_module.ctera_return_value().changed().msg('Cloud Folder deleted').put(name=self.parameters['name'])
+        else:
+            self.ansible_module.ctera_return_value().skipped().msg('Cloud Folder already does not exist').put(name=self.parameters['name'])
+
+    @staticmethod
+    def _make_user_account(user_details):
+        return portal_types.UserAccount(**user_details) if user_details else None
+
+
+def main():  # pragma: no cover
+    CteraPortalCloudFolder().run()
+
+
+if __name__ == '__main__':  # pragma: no cover
+    main()

--- a/ansible_collections/ctera/ctera/plugins/modules/ctera_portal_folder_group.py
+++ b/ansible_collections/ctera/ctera/plugins/modules/ctera_portal_folder_group.py
@@ -1,0 +1,157 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2020, CTERA Networks Ltd.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: ctera_portal_folder_group
+short_description: CTERA-Networks Portal folder group configuration and management
+description:
+    - Create, and delete folder groups.
+extends_documentation_fragment:
+    - ctera.ctera.vportal
+
+author:
+    - Saimon Michelson (@saimonation)
+    - Ygal Blum (@ygalblum)
+
+options:
+  state:
+    description:
+    - Whether the specified user should exist or not.
+    type: str
+    choices: ['present', 'absent']
+    default: 'present'
+  name:
+    description: The name of the folder group
+    required: True
+    type: str
+  owner:
+    description: The folder group owner
+    type: dict
+    suboptions:
+      name:
+        description: The user name
+        required: True
+        type: str
+      directory:
+        description: The fully-qualified name of the user directory, if the user belongs to one
+        type: str
+
+'''
+
+EXAMPLES = '''
+- name: No Owner Folder Group
+  ctera_portal_folder_group:
+    name: 'CompanyMain'
+    ctera_host: "{{ ctera_portal_hostname }}"
+    ctera_user: "{{ ctera_portal_user }}"
+    ctera_password: "{{ ctera_portal_password }}"
+
+- name: User Owned Folder Group
+  ctera_portal_folder_group:
+    name: "CompanyMain"
+    owner:
+      name: "Alice"
+    ctera_host: "{{ ctera_portal_hostname }}"
+    ctera_user: "{{ ctera_portal_user }}"
+    ctera_password: "{{ ctera_portal_password }}"
+
+'''
+
+RETURN = '''
+name:
+  description: Name of the folder group
+  returned: when state is present
+  type: str
+  sample: CompanyMain
+'''
+
+from ansible_collections.ctera.ctera.plugins.module_utils.ctera_portal_base import CteraPortalBase
+
+try:
+    from cterasdk import CTERAException, portal_types
+except ImportError:  # pragma: no cover
+    pass  # caught by ctera_common
+
+
+class CteraPortalFolderGroup(CteraPortalBase):
+    def __init__(self):
+        super().__init__(
+            dict(
+                state=dict(required=False, choices=['present', 'absent'], default='present'),
+                name=dict(type='str', required=True),
+                owner=dict(
+                    type='dict',
+                    required=False,
+                    options=dict(
+                        name=dict(type='str', required=True),
+                        directory=dict(type='str')
+                    )
+                ),
+            )
+        )
+
+    @property
+    def _generic_failure_message(self):  # pragma: no cover
+        return 'Folder Group management failed'
+
+    def _execute(self):
+        state = self.parameters.pop('state')
+        folder_group = self._get_folder_group()
+        if state == 'present':
+            self._ensure_present(folder_group)
+        else:
+            self._ensure_absent(folder_group)
+
+    def _get_folder_group(self):
+        folder_group = []
+        try:
+            folder_group = self._ctera_portal.cloudfs.get(self.parameters['name'])
+        except CTERAException:
+            pass
+        return self._to_folder_group_dict(folder_group) if folder_group else None
+
+    @staticmethod
+    def _make_user_account(user_details):
+        return portal_types.UserAccount(**user_details) if user_details else None
+
+    @staticmethod
+    def _to_folder_group_dict(folder_group):
+        return dict(
+            name=folder_group.name,
+            owner=dict(name=folder_group.owner.split('/')[-1]) if folder_group.owner else None
+        )
+
+    def _ensure_present(self, folder_group):
+        if folder_group:
+            self.ansible_module.ctera_return_value().skipped().msg('Folder Group already exists').put(name=self.parameters['name'])
+        else:
+            self._ctera_portal.cloudfs.mkfg(self.parameters['name'], user=self._make_user_account(self.parameters.get('owner')))
+            self.ansible_module.ctera_return_value().changed().msg('Folder Group created').put(name=self.parameters['name'])
+
+    def _ensure_absent(self, folder_group):
+        if folder_group:
+            self._ctera_portal.cloudfs.rmfg(self.parameters['name'])
+            self.ansible_module.ctera_return_value().changed().msg('Folder Group deleted').put(name=self.parameters['name'])
+        else:
+            self.ansible_module.ctera_return_value().skipped().msg('Folder Group already does not exist').put(name=self.parameters['name'])
+
+
+def main():  # pragma: no cover
+    CteraPortalFolderGroup().run()
+
+
+if __name__ == '__main__':  # pragma: no cover
+    main()

--- a/ansible_collections/ctera/ctera/plugins/modules/ctera_portal_init_application_server.py
+++ b/ansible_collections/ctera/ctera/plugins/modules/ctera_portal_init_application_server.py
@@ -1,0 +1,96 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2020, CTERA Networks Ltd.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: ctera_portal_init_application_server
+short_description: CTERA-Networks Portal Application Server Initialization
+description:
+    - Initialize Portal Application Server
+extends_documentation_fragment:
+    - ctera.ctera.vportal
+
+author:
+    - Saimon Michelson (@saimonation)
+    - Ygal Blum (@ygalblum)
+
+options:
+  ipaddr:
+    description: The CTERA Portal application server IP address
+    required: True
+    type: str
+  secret:
+    description: A password or a PEM-encoded private key
+    type: str
+
+'''
+
+EXAMPLES = '''
+- name: initialize portal application server
+  ctera_portal_init_application_server:
+    ipaddr: 192.168.1.1
+    secret: 'su@p3rsecret!!'
+    ctera_host: "{{ ctera_app_hostname }}"
+    ctera_user: "{{ ctera_app_user }}"
+    ctera_password: "{{ ctera_app_password }}"
+'''
+
+RETURN = r''' # '''
+
+try:
+    from cterasdk import portal_enum
+except ImportError:  # pragma: no cover
+    pass  # caught by ctera_common
+
+from ansible_collections.ctera.ctera.plugins.module_utils.ctera_portal_base import CteraPortalBase
+
+
+class CteraPortalInitApplication(CteraPortalBase):
+    _configure_params = ['ipaddr', 'secret']
+
+    def __init__(self):
+        super().__init__(
+            dict(
+                ipaddr=dict(type='str', required=True),
+                secret=dict(type='str', required=False),
+            ),
+            login=False
+        )
+
+    @property
+    def _generic_failure_message(self):  # pragma: no cover
+        return 'Portal Initialization failed'
+
+    def _execute(self):
+        if self._is_already_configured():
+            self.ansible_module.ctera_return_value().skipped().msg('The Portal Application Server is already configured ')
+            return
+        self._configure_application_server()
+
+    def _is_already_configured(self):
+        setup_status = self._ctera_portal.setup.get_setup_status()
+        return setup_status.wizard == portal_enum.SetupWizardStage.Finish
+
+    def _configure_application_server(self):
+        configure_params = {k: v for k, v in self.parameters.items() if k in CteraPortalInitApplication._configure_params}
+        self._ctera_portal.setup.init_application_server(**configure_params)
+
+
+def main():  # pragma: no cover
+    CteraPortalInitApplication().run()
+
+
+if __name__ == '__main__':  # pragma: no cover
+    main()

--- a/ansible_collections/ctera/ctera/plugins/modules/ctera_portal_init_master.py
+++ b/ansible_collections/ctera/ctera/plugins/modules/ctera_portal_init_master.py
@@ -1,0 +1,111 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2020, CTERA Networks Ltd.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: ctera_portal_init_master
+short_description: CTERA-Networks Portal Master Initialization
+description:
+    - Initialize Portal Master
+extends_documentation_fragment:
+    - ctera.ctera.vportal
+
+author:
+    - Saimon Michelson (@saimonation)
+    - Ygal Blum (@ygalblum)
+
+options:
+  email:
+    description: The e-mail address of the user
+    type: str
+    required: True
+  first_name:
+    description: The first name of the user
+    type: str
+    required: True
+  last_name:
+    description: The first name of the user
+    type: str
+    required: True
+  domain:
+    description: The domain suffix for CTERA Portal
+    type: str
+    required: True
+
+'''
+
+EXAMPLES = '''
+- name: initialize portal master
+  ctera_portal_init_master:
+    email: 'admin@example.com'
+    first_name: 'Admin'
+    last_name: 'Adminson'
+    domain: 'ctera.me'
+    ctera_host: "{{ ctera_portal_hostname }}"
+    ctera_user: "{{ ctera_portal_user }}"
+    ctera_password: "{{ ctera_portal_password }}"
+'''
+
+RETURN = r''' # '''
+
+try:
+    from cterasdk import portal_enum
+except ImportError:  # pragma: no cover
+    pass  # caught by ctera_common
+
+from ansible_collections.ctera.ctera.plugins.module_utils.ctera_portal_base import CteraPortalBase
+
+
+class CteraPortalInitMaster(CteraPortalBase):
+    _configure_params = ['email', 'first_name', 'last_name', 'domain']
+
+    def __init__(self):
+        super().__init__(
+            dict(
+                email=dict(type='str', required=True),
+                first_name=dict(type='str', required=True),
+                last_name=dict(type='str', required=True),
+                domain=dict(type='str', required=True),
+            ),
+            login=False
+        )
+
+    @property
+    def _generic_failure_message(self):  # pragma: no cover
+        return 'Portal Initialization failed'
+
+    def _execute(self):
+        if self._is_already_configured():
+            self.ansible_module.ctera_return_value().skipped().msg('The Portal Master Server is already configured ')
+        else:
+            self._configure_master()
+
+    def _is_already_configured(self):
+        setup_status = self._ctera_portal.setup.get_setup_status()
+        return setup_status.wizard == portal_enum.SetupWizardStage.Finish
+
+    def _configure_master(self):
+        configure_params = {k: v for k, v in self.parameters.items() if k in CteraPortalInitMaster._configure_params}
+        configure_params['name'] = self.parameters['ctera_user']
+        configure_params['password'] = self.parameters['ctera_password']
+        self._ctera_portal.setup.init_master(**configure_params)
+
+
+def main():  # pragma: no cover
+    CteraPortalInitMaster().run()
+
+
+if __name__ == '__main__':  # pragma: no cover
+    main()

--- a/ansible_collections/ctera/ctera/plugins/modules/ctera_portal_local_user.py
+++ b/ansible_collections/ctera/ctera/plugins/modules/ctera_portal_local_user.py
@@ -1,0 +1,195 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2020, CTERA Networks Ltd.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: ctera_portal_local_user
+short_description: CTERA-Networks Portal user configuration and management
+description:
+    - Create, modify and delete users.
+extends_documentation_fragment:
+    - ctera.ctera.vportal
+
+author:
+    - Saimon Michelson (@saimonation)
+    - Ygal Blum (@ygalblum)
+
+options:
+  state:
+    description:
+    - Whether the specified user should exist or not.
+    type: str
+    choices: ['present', 'absent']
+    default: 'present'
+  name:
+    description: The name of the user
+    required: True
+    type: str
+  email:
+    description: The e-mail address of the user
+    type: str
+  first_name:
+    description: The first name of the user
+    type: str
+  last_name:
+    description: The first name of the user
+    type: str
+  password:
+    description:
+    - The password of the user
+    - Required when C(state=present) and the user does not exist
+    - If the user exists, the new password will be set
+    type: str
+  update_password:
+    description: If True, and user exists, the password will be updated
+    type: bool
+    default: False
+  role:
+    description:
+    - User role of the new user
+    type: str
+    choices: ['Disabled', 'EndUser', 'ReadWriteAdmin', 'ReadOnlyAdmin', 'Support']
+    default: 'Disabled'
+  company:
+    description: The name of the company of the user
+    type: str
+  comment:
+    description: Additional comment for the user
+    type: str
+  password_change:
+    description:
+    - Whether to enforce a password change
+    - Pass a string in the format of '%Y-%m-%d' for a specific date, integer for days from creation, or True for immediate , defaults to False.
+    type: raw
+    default: False
+
+'''
+
+EXAMPLES = '''
+- name: create local user
+  ctera_portal_local_user:
+    name: 'alice'
+    email: 'walice@wonderland.com'
+    first_name: 'Alice'
+    last_name: 'Wonderland'
+    password: 'su@p3rsecret!!'
+    role: 'ReadWriteAdmin'
+    ctera_host: "{{ ctera_portal_hostname }}"
+    ctera_user: "{{ ctera_portal_user }}"
+    ctera_password: "{{ ctera_portal_password }}"
+'''
+
+RETURN = '''
+name:
+  description: User name of the user
+  returned: when state is present
+  type: str
+  sample: admin
+'''
+import datetime
+
+import ansible_collections.ctera.ctera.plugins.module_utils.ctera_common as ctera_common
+from ansible_collections.ctera.ctera.plugins.module_utils.ctera_portal_base import CteraPortalBase
+
+try:
+    from cterasdk import CTERAException, portal_types
+except ImportError:  # pragma: no cover
+    pass  # caught by ctera_common
+
+
+class CteraPortalLocalUser(CteraPortalBase):
+    _create_params = ['name', 'email', 'first_name', 'last_name', 'password', 'role', 'company', 'comment', 'password_change']
+
+    def __init__(self):
+        super().__init__(
+            dict(
+                state=dict(required=False, choices=['present', 'absent'], default='present'),
+                name=dict(type='str', required=True),
+                email=dict(type='str', required=False),
+                first_name=dict(type='str', required=False),
+                last_name=dict(type='str', required=False),
+                password=dict(type='str', required=False, no_log=True),
+                update_password=dict(type='bool', default=False),
+                role=dict(type='str', required=False, choices=['Disabled', 'EndUser', 'ReadWriteAdmin', 'ReadOnlyAdmin', 'Support'], default='Disabled'),
+                company=dict(type='str', required=False),
+                comment=dict(type='str', required=False),
+                password_change=dict(type='raw', required=False, default=False)
+            )
+        )
+
+    @property
+    def _generic_failure_message(self):  # pragma: no cover
+        return 'User management failed'
+
+    def _execute(self):
+        state = self.parameters.pop('state')
+        user = self._get_user()
+        if state == 'present':
+            self._ensure_present(user)
+        else:
+            self._ensure_absent(user)
+
+    def _get_user(self):
+        user = None
+        try:
+            user = self._ctera_portal.users.get(portal_types.UserAccount(self.parameters['name']), include=CteraPortalLocalUser._create_params)
+        except CTERAException:
+            pass
+        return self._to_user_dict(user) if user else None
+
+    @staticmethod
+    def _translate_password_change(password_change):
+        if isinstance(password_change, str):
+            return datetime.datetime.strptime(password_change, '%Y-%m-%d').date()
+        return password_change
+
+    def _ensure_present(self, user):
+        update_password = self.parameters.pop('update_password')
+        if user:
+            self.parameters.pop('password_change', None)
+            if not update_password:
+                self.parameters.pop('password', None)
+            modified_attributes = ctera_common.get_modified_attributes(user, self.parameters)
+            if modified_attributes:
+                self._ctera_portal.users.modify(self.parameters['name'], **modified_attributes)
+                self.ansible_module.ctera_return_value().changed().msg('User modified').put(name=self.parameters['name'])
+            else:
+                self.ansible_module.ctera_return_value().skipped().msg('User details did not change').put(name=self.parameters['name'])
+        else:
+            self.parameters['password_change'] = self._translate_password_change(self.parameters['password_change'])
+            create_params = {k: v for k, v in self.parameters.items() if k in CteraPortalLocalUser._create_params}
+            if create_params.get('password') is None:
+                raise CTERAException(message="Cannot create new user without a password")
+            self._ctera_portal.users.add(**create_params)
+            self.ansible_module.ctera_return_value().changed().msg('User created').put(**create_params)
+
+    def _ensure_absent(self, user):
+        if user:
+            self._ctera_portal.users.delete(portal_types.UserAccount(self.parameters['name']))
+            self.ansible_module.ctera_return_value().changed().msg('User deleted').put(name=self.parameters['name'])
+        else:
+            self.ansible_module.ctera_return_value().skipped().msg('User already does not exist').put(name=self.parameters['name'])
+
+    @staticmethod
+    def _to_user_dict(user):
+        return {k: v for k, v in user.__dict__.items() if not k.startswith("_")}
+
+
+def main():  # pragma: no cover
+    CteraPortalLocalUser().run()
+
+
+if __name__ == '__main__':  # pragma: no cover
+    main()

--- a/ansible_collections/ctera/ctera/plugins/modules/ctera_portal_plan.py
+++ b/ansible_collections/ctera/ctera/plugins/modules/ctera_portal_plan.py
@@ -1,0 +1,237 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2020, CTERA Networks Ltd.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {
+    'metadata_version': '1.1',
+    'status': ['preview'],
+    'supported_by': 'community'
+}
+
+DOCUMENTATION = '''
+---
+module: ctera_portal_plan
+short_description: CTERA-Networks Portal Plan configuration and management
+description:
+    - Create, modify and delete plans.
+extends_documentation_fragment:
+    - ctera.ctera.vportal
+
+author:
+    - Saimon Michelson (@saimonation)
+    - Ygal Blum (@ygalblum)
+
+options:
+  state:
+    description:
+    - Whether the specified plan should exist or not.
+    type: str
+    choices: ['present', 'absent']
+    default: 'present'
+  name:
+    description: The name of the plan
+    required: True
+    type: str
+  retention:
+    description: The data retention policy
+    type: list
+    elements: dict
+    suboptions:
+      policy_name:
+        description: The name of the policy
+        type: str
+        required: True
+        choices:
+          - retainAll
+          - hourly
+          - daily
+          - weekly
+          - monthly
+          - quarterly
+          - yearly
+          - retainDeleted
+      duration:
+        description: The duration for the policy
+        type: int
+        required: True
+  quotas:
+    description: The items included in the plan and their respective quota
+    type: list
+    elements: dict
+    suboptions:
+      item_name:
+        description: The name of the plan item
+        type: str
+        required: True
+        choices:
+        - EV4
+        - EV8
+        - EV16
+        - EV32
+        - EV64
+        - EV128
+        - WA
+        - SA
+        - Share
+        - Connect
+      amount:
+        description: The quota's amount
+        type: int
+        required: True
+
+'''
+
+EXAMPLES = '''
+- name: Portal Plan
+  ctera_portal_plan:
+    name: 'example'
+    retention:
+    - policy_name: retainAll
+      duration: 24
+    quotas:
+    - item_name: EV16
+      amount: 100
+    ctera_host: "{{ ctera_portal_hostname }}"
+    ctera_user: "{{ ctera_portal_user }}"
+    ctera_password: "{{ ctera_portal_password }}"
+'''
+
+RETURN = '''
+name:
+  description: Name of the Plan
+  returned: when state is present
+  type: str
+  sample: example
+'''
+import ansible_collections.ctera.ctera.plugins.module_utils.ctera_common as ctera_common
+from ansible_collections.ctera.ctera.plugins.module_utils.ctera_portal_base import CteraPortalBase
+
+try:
+    from cterasdk import CTERAException
+except ImportError:  # pragma: no cover
+    pass  # caught by ctera_common
+
+
+class CteraPortalPlan(CteraPortalBase):
+    _create_params = ['name', 'email', 'first_name', 'last_name', 'password', 'role', 'company', 'comment', 'password_change']
+    _retention_policy_names = ['retainAll', 'hourly', 'daily', 'weekly', 'monthly', 'quarterly', 'yearly', 'retainDeleted']
+    _quotas_item_names = ['EV4', 'EV8', 'EV16', 'EV32', 'EV64', 'EV128', 'WA', 'SA', 'Share', 'Connect']
+
+    def __init__(self):
+        super().__init__(
+            dict(
+                state=dict(required=False, choices=['present', 'absent'], default='present'),
+                name=dict(type='str', required=True),
+                retention=dict(
+                    type='list',
+                    elements='dict',
+                    options=dict(
+                        policy_name=dict(type='str', required=True, choices=CteraPortalPlan._retention_policy_names),
+                        duration=dict(type='int', required=True)
+                    )
+                ),
+                quotas=dict(
+                    type='list',
+                    elements='dict',
+                    options=dict(
+                        item_name=dict(type='str', required=True, choices=CteraPortalPlan._quotas_item_names),
+                        amount=dict(type='int', required=True)
+                    )
+                )
+            )
+        )
+
+    @property
+    def _generic_failure_message(self):  # pragma: no cover
+        return 'Plan management failed'
+
+    def _execute(self):
+        state = self.parameters.pop('state')
+        plan = self._get_plan()
+        if state == 'present':
+            self._ensure_present(plan)
+        else:
+            self._ensure_absent(plan)
+
+    def _get_plan(self):
+        plan = None
+        try:
+            plan = self._ctera_portal.plans.get(
+                self.parameters['name'],
+                include=[
+                    'name',
+                    'retentionPolicy',
+                    'vGateways4',
+                    'vGateways8',
+                    'appliances',
+                    'vGateways32',
+                    'vGateways64',
+                    'vGateways128',
+                    'workstationAgents',
+                    'serverAgents',
+                    'cloudDrives',
+                    'cloudDrivesLite'
+                ]
+            )
+        except CTERAException:
+            pass
+        return self._to_plan_dict(plan) if plan else None
+
+    def _ensure_present(self, plan):
+        if plan:
+            modified_attributes = ctera_common.get_modified_attributes(plan, self.parameters)
+            if modified_attributes:
+                self._ctera_portal.plans.modify(self.parameters['name'], **self._translate_params_obj(modified_attributes))
+                self.ansible_module.ctera_return_value().changed().msg('Plan modified').put(name=self.parameters['name'])
+            else:
+                self.ansible_module.ctera_return_value().skipped().msg('Plan details did not change').put(name=self.parameters['name'])
+        else:
+            self._ctera_portal.plans.add(self.parameters['name'], **self._translate_params_obj(self.parameters))
+            self.ansible_module.ctera_return_value().changed().msg('Plan created').put(name=self.parameters['name'])
+
+    @staticmethod
+    def _translate_params_obj(parameters):
+        return dict(
+            retention={i['policy_name']: i['duration'] for i in parameters['retention']} if parameters.get('retention') else None,
+            quotas={i['item_name']: i['amount'] for i in parameters['quotas']} if parameters.get('quotas') else None
+        )
+
+    def _ensure_absent(self, plan):
+        if plan:
+            self._ctera_portal.plans.delete(self.parameters['name'])
+            self.ansible_module.ctera_return_value().changed().msg('Plan deleted').put(name=self.parameters['name'])
+        else:
+            self.ansible_module.ctera_return_value().skipped().msg('Plan already does not exist').put(name=self.parameters['name'])
+
+    @staticmethod
+    def _to_plan_dict(plan):
+        return dict(
+            name=plan.name,
+            retention=[
+                dict(policy_name=k, duration=v) for k, v in plan.retentionPolicy.__dict__.items() if not k.startswith("_")
+            ],
+            quotas=[
+                dict(item_name='EV4', amount=plan.vGateways4.amount),
+                dict(item_name='EV8', amount=plan.vGateways8.amount),
+                dict(item_name='EV16', amount=plan.appliances.amount),
+                dict(item_name='EV64', amount=plan.vGateways64.amount),
+                dict(item_name='EV128', amount=plan.vGateways128.amount),
+                dict(item_name='WA', amount=plan.workstationAgents.amount),
+                dict(item_name='SA', amount=plan.serverAgents.amount),
+                dict(item_name='Share', amount=plan.cloudDrives.amount),
+                dict(item_name='Connect', amount=plan.cloudDrivesLite.amount),
+            ]
+        )
+
+
+def main():  # pragma: no cover
+    CteraPortalPlan().run()
+
+
+if __name__ == '__main__':  # pragma: no cover
+    main()

--- a/tests/ut/mocks/ansible_module_mock.py
+++ b/tests/ut/mocks/ansible_module_mock.py
@@ -1,15 +1,15 @@
-filer_trust_certificate = False
+trust_certificate = False
 
 class AnsibleModuleMock():
 
     def __init__(self, _argument_spec, **_kwargs):
         self.params = dict(
-            filer_host='192.168.1.1',
-            filer_user='admin',
-            filer_https=True,
-            filer_port=None,
-            filer_password='password',
-            filer_trust_certificate=filer_trust_certificate
+            ctera_host='192.168.1.1',
+            ctera_user='admin',
+            ctera_https=True,
+            ctera_port=None,
+            ctera_password='password',
+            ctera_trust_certificate=trust_certificate
         )
         self.fail_dict = {}
         self.exit_dict = {}

--- a/tests/ut/mocks/ctera_portal_base_mock.py
+++ b/tests/ut/mocks/ctera_portal_base_mock.py
@@ -1,0 +1,35 @@
+import unittest.mock as mock
+
+from ansible_collections.ctera.ctera.plugins.module_utils.ctera_common import AnsibleReturnValue
+
+class CteraFilerBaseMock():
+    def __init__(self, _argument_spec, **_kwargs):
+        self._ctera_portal = mock.MagicMock()
+        self._ctera_portal.users = mock.MagicMock()
+        self._ctera_portal.users.add = mock.MagicMock()
+        self._ctera_portal.users.delete = mock.MagicMock()
+        self._ctera_portal.users.get = mock.MagicMock()
+        self._ctera_portal.users.list_local_users = mock.MagicMock()
+        self._ctera_portal.users.list_domains = mock.MagicMock()
+        self._ctera_portal.users.list_domain_users = mock.MagicMock()
+        self._ctera_portal.users.modify = mock.MagicMock()
+
+        self.ansible_module = mock.MagicMock()
+        self.ansible_return_value = AnsibleReturnValue()
+        self.ansible_module.ctera_return_value = mock.MagicMock(return_value=self.ansible_return_value)
+
+    def run(self):
+        self._execute()
+
+    def _execute(self):
+        pass
+
+
+def mock_bases(test, klass):
+    original_bases = klass.__bases__
+    klass.__bases__ = (CteraFilerBaseMock,)
+    test.addCleanup(restore_bases, klass, original_bases)
+
+
+def restore_bases(klass, bases):
+    klass.__bases__ = bases

--- a/tests/ut/module_utils/test_ctera_ansible_module.py
+++ b/tests/ut/module_utils/test_ctera_ansible_module.py
@@ -1,0 +1,91 @@
+# This code is part of Ansible, but is an independent component.
+# This particular file snippet, and this file snippet only, is licensed under the Apache License 2.0.
+# Modules you write using this snippet, which is embedded dynamically by Ansible
+# still belong to the author of the module, and may assign their own license
+# to the complete work.
+#
+# Copyright 2020, CTERA Networks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import unittest.mock as mock
+
+try:
+    from cterasdk import CTERAException
+    from cterasdk import config as ctera_config
+except ImportError:  # pragma: no cover
+    pass
+
+import ansible_collections.ctera.ctera.plugins.module_utils.ctera_ansible_module as ctera_ansible_module
+from tests.ut.mocks import ansible_module_mock
+from tests.ut.base import BaseTest
+
+
+class TestCteraAnsibleModule(BaseTest):  #pylint: disable=too-many-public-methods
+
+    def setUp(self):
+        super().setUp()
+        ansible_module_mock.mock_bases(self, ctera_ansible_module.CteraAnsibleModule)
+        self.ansible_return_value_class_mock = self.patch_call(
+            "ansible_collections.ctera.ctera.plugins.module_utils.ctera_ansible_module.ctera_common.AnsibleReturnValue"
+        )
+        self.ansible_return_value_object_mock = self.ansible_return_value_class_mock.return_value
+
+    def test_no_cterasdk(self):
+        cterasdk_imp_err = "Failed to import"
+        self.patch_call("ansible_collections.ctera.ctera.plugins.module_utils.ctera_ansible_module.ctera_common.HAS_CTERASDK", new=False)
+        self.patch_call("ansible_collections.ctera.ctera.plugins.module_utils.ctera_ansible_module.ctera_common.CTERASDK_IMP_ERR", new=cterasdk_imp_err)
+        ansible_module = ctera_ansible_module.CteraAnsibleModule(dict())
+        self.assertDictEqual(ansible_module.fail_dict, dict(msg=mock.ANY, exception=cterasdk_imp_err))
+
+    @staticmethod
+    def test_ctera_portal_logout():
+        ansible_module = ctera_ansible_module.CteraAnsibleModule(dict())
+        ansible_module._ctera_host = mock.MagicMock()  # pylint: disable=protected-access
+        ansible_module._ctera_host.logout = mock.MagicMock(return_value=None)  # pylint: disable=protected-access
+        ansible_module.ctera_logout()
+        ansible_module._ctera_host.logout.assert_called_once_with()  # pylint: disable=protected-access
+
+    def test_ctera_return_value(self):
+        ansible_module = ctera_ansible_module.CteraAnsibleModule(dict())
+        ansible_return_value = ansible_module.ctera_return_value()
+        self.assertEqual(self.ansible_return_value_object_mock, ansible_return_value)
+
+    def test_ctera_exit(self):
+        for has_failed in [True, False]:
+            self._test_ctera_exit(has_failed)
+
+    def _test_ctera_exit(self, has_failed):
+        self.ansible_return_value_object_mock.has_failed.return_value = has_failed
+        expected_dict = dict(msg='Success')
+        self.ansible_return_value_object_mock.as_dict.return_value = expected_dict
+        ansible_module = ctera_ansible_module.CteraAnsibleModule(dict())
+        ansible_module.ctera_exit()
+        if has_failed:
+            self.assertDictEqual(ansible_module.exit_dict, {})
+            self.assertDictEqual(ansible_module.fail_dict, expected_dict)
+        else:
+            self.assertDictEqual(ansible_module.exit_dict, expected_dict)
+            self.assertDictEqual(ansible_module.fail_dict, {})
+
+    def test_trust_certificate(self):
+        for trust in [True, False]:
+            self._test_trust_certificate(trust)
+
+    def _test_trust_certificate(self, trust):
+        ansible_module_mock.trust_certificate = trust
+        ctera_ansible_module.CteraAnsibleModule(dict())
+        self.assertEqual(ctera_config.http['ssl'], 'Trust' if trust else 'Consent')

--- a/tests/ut/module_utils/test_ctera_edge.py
+++ b/tests/ut/module_utils/test_ctera_edge.py
@@ -28,6 +28,7 @@ try:
 except ImportError:  # pragma: no cover
     pass
 
+import ansible_collections.ctera.ctera.plugins.module_utils.ctera_ansible_module as ctera_ansible_module
 import ansible_collections.ctera.ctera.plugins.module_utils.ctera_edge as ctera_edge
 from tests.ut.mocks import ansible_module_mock
 from tests.ut.base import BaseTest
@@ -37,22 +38,15 @@ class TestCteraEdge(BaseTest):  #pylint: disable=too-many-public-methods
 
     def setUp(self):
         super().setUp()
-        ansible_module_mock.mock_bases(self, ctera_edge.GatewayAnsibleModule)
+        ansible_module_mock.mock_bases(self, ctera_ansible_module.CteraAnsibleModule)
 
         self.gateway_class_mock = self.patch_call("ansible_collections.ctera.ctera.plugins.module_utils.ctera_edge.Gateway")
         self.gateway_object_mock = self.gateway_class_mock.return_value
 
         self.ansible_return_value_class_mock = self.patch_call(
-            "ansible_collections.ctera.ctera.plugins.module_utils.ctera_edge.ctera_common.AnsibleReturnValue"
+            "ansible_collections.ctera.ctera.plugins.module_utils.ctera_ansible_module.ctera_common.AnsibleReturnValue"
         )
         self.ansible_return_value_object_mock = self.ansible_return_value_class_mock.return_value
-
-    def test_no_cterasdk(self):
-        cterasdk_imp_err = "Failed to import"
-        self.patch_call("ansible_collections.ctera.ctera.plugins.module_utils.ctera_edge.ctera_common.HAS_CTERASDK", new=False)
-        self.patch_call("ansible_collections.ctera.ctera.plugins.module_utils.ctera_edge.ctera_common.CTERASDK_IMP_ERR", new=cterasdk_imp_err)
-        gateway_ansible_module = ctera_edge.GatewayAnsibleModule(dict())
-        self.assertDictEqual(gateway_ansible_module.fail_dict, dict(msg=mock.ANY, exception=cterasdk_imp_err))
 
     def test_ctera_filer_with_login(self):
         self.gateway_object_mock.login = mock.MagicMock(return_value=None)
@@ -74,47 +68,3 @@ class TestCteraEdge(BaseTest):  #pylint: disable=too-many-public-methods
         self.gateway_class_mock.assert_called_once_with('192.168.1.1', https=True, port=None)
         gateway_ansible_module.ctera_filer(login=False)
         self.gateway_object_mock.login.assert_not_called()
-
-    def test_ctera_filer_logout(self):
-        self.gateway_object_mock.logout = mock.MagicMock(return_value=None)
-        gateway_ansible_module = ctera_edge.GatewayAnsibleModule(dict())
-        self.gateway_class_mock.assert_called_once_with('192.168.1.1', https=True, port=None)
-        gateway_ansible_module.ctera_logout()
-        self.gateway_object_mock.logout.assert_called_once_with()
-
-    def test_ctera_return_value(self):
-        gateway_ansible_module = ctera_edge.GatewayAnsibleModule(dict())
-        self.gateway_class_mock.assert_called_once_with('192.168.1.1', https=True, port=None)
-        ansible_return_value = gateway_ansible_module.ctera_return_value()
-        self.assertEqual(self.ansible_return_value_object_mock, ansible_return_value)
-
-    def test_ctera_exit_success(self):
-        self._test_ctera_exit(False)
-
-    def test_ctera_exit_failure(self):
-        self._test_ctera_exit(True)
-
-    def _test_ctera_exit(self, has_failed):
-        self.ansible_return_value_object_mock.has_failed.return_value = has_failed
-        expected_dict = dict(msg='Success')
-        self.ansible_return_value_object_mock.as_dict.return_value = expected_dict
-        gateway_ansible_module = ctera_edge.GatewayAnsibleModule(dict())
-        self.gateway_class_mock.assert_called_once_with('192.168.1.1', https=True, port=None)
-        gateway_ansible_module.ctera_exit()
-        if has_failed:
-            self.assertDictEqual(gateway_ansible_module.exit_dict, {})
-            self.assertDictEqual(gateway_ansible_module.fail_dict, expected_dict)
-        else:
-            self.assertDictEqual(gateway_ansible_module.exit_dict, expected_dict)
-            self.assertDictEqual(gateway_ansible_module.fail_dict, {})
-
-    def test_filer_trust_certificate_true(self):
-        self._test_filer_trust_certificate(True)
-
-    def test_filer_trust_certificate_false(self):
-        self._test_filer_trust_certificate(False)
-
-    def _test_filer_trust_certificate(self, trust):
-        ansible_module_mock.filer_trust_certificate = trust
-        ctera_edge.GatewayAnsibleModule(dict())
-        self.assertEqual(ctera_edge.config.http['ssl'], 'Trust' if trust else 'Consent')

--- a/tests/ut/module_utils/test_ctera_portal.py
+++ b/tests/ut/module_utils/test_ctera_portal.py
@@ -1,0 +1,77 @@
+# This code is part of Ansible, but is an independent component.
+# This particular file snippet, and this file snippet only, is licensed under the Apache License 2.0.
+# Modules you write using this snippet, which is embedded dynamically by Ansible
+# still belong to the author of the module, and may assign their own license
+# to the complete work.
+#
+# Copyright 2020, CTERA Networks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import unittest.mock as mock
+
+try:
+    from cterasdk import CTERAException
+except ImportError:  # pragma: no cover
+    pass
+
+import ansible_collections.ctera.ctera.plugins.module_utils.ctera_ansible_module as ctera_ansible_module
+import ansible_collections.ctera.ctera.plugins.module_utils.ctera_portal as ctera_portal
+from tests.ut.mocks import ansible_module_mock
+from tests.ut.base import BaseTest
+
+
+class TestCteraPortal(BaseTest):  #pylint: disable=too-many-public-methods
+
+    def setUp(self):
+        super().setUp()
+        ansible_module_mock.mock_bases(self, ctera_ansible_module.CteraAnsibleModule)
+
+        self.portal_class_mock = self.patch_call("ansible_collections.ctera.ctera.plugins.module_utils.ctera_portal.GlobalAdmin")
+        self.portal_object_mock = self.portal_class_mock.return_value
+
+        self.ansible_return_value_class_mock = self.patch_call(
+            "ansible_collections.ctera.ctera.plugins.module_utils.ctera_ansible_module.ctera_common.AnsibleReturnValue"
+        )
+        self.ansible_return_value_object_mock = self.ansible_return_value_class_mock.return_value
+
+    def test_no_cterasdk(self):
+        cterasdk_imp_err = "Failed to import"
+        self.patch_call("ansible_collections.ctera.ctera.plugins.module_utils.ctera_ansible_module.ctera_common.HAS_CTERASDK", new=False)
+        self.patch_call("ansible_collections.ctera.ctera.plugins.module_utils.ctera_ansible_module.ctera_common.CTERASDK_IMP_ERR", new=cterasdk_imp_err)
+        portal_ansible_module = ctera_portal.PortalAnsibleModule(dict())
+        self.assertDictEqual(portal_ansible_module.fail_dict, dict(msg=mock.ANY, exception=cterasdk_imp_err))
+
+    def test_ctera_portal_with_login(self):
+        self.portal_object_mock.login = mock.MagicMock(return_value=None)
+        portal_ansible_module = ctera_portal.PortalAnsibleModule(dict())
+        self.portal_class_mock.assert_called_once_with('192.168.1.1', https=True, port=None)
+        portal_ansible_module.ctera_portal()
+        self.portal_object_mock.login.assert_called_once_with('admin', 'password')
+
+    def test_ctera_portal_login_failed(self):
+        self.portal_object_mock.login = mock.MagicMock(side_effect=CTERAException())
+        portal_ansible_module = ctera_portal.PortalAnsibleModule(dict())
+        self.portal_class_mock.assert_called_once_with('192.168.1.1', https=True, port=None)
+        portal_ansible_module.ctera_portal()
+        self.portal_object_mock.login.assert_called_once_with('admin', 'password')
+
+    def test_ctera_portal_no_login(self):
+        self.portal_object_mock.login = mock.MagicMock(return_value=None)
+        portal_ansible_module = ctera_portal.PortalAnsibleModule(dict())
+        self.portal_class_mock.assert_called_once_with('192.168.1.1', https=True, port=None)
+        portal_ansible_module.ctera_portal(login=False)
+        self.portal_object_mock.login.assert_not_called()

--- a/tests/ut/module_utils/test_ctera_portal_base.py
+++ b/tests/ut/module_utils/test_ctera_portal_base.py
@@ -1,0 +1,88 @@
+import unittest.mock as mock
+
+try:
+    from cterasdk import CTERAException
+except ImportError:  # pragma: no cover
+    pass
+
+from ansible_collections.ctera.ctera.plugins.module_utils import ctera_portal_base
+from tests.ut.mocks.gateway_ansible_module_mock import mock_gateway_ansible_module
+from tests.ut.base import BaseTest
+
+
+class CteraPortalTestChild(ctera_portal_base.CteraPortalBase):
+
+    def __init__(self, success):
+        super().__init__({})
+        self._success = success
+        self.execute_called = False
+        self.generic_failure_message_called = False
+
+    @property
+    def _generic_failure_message(self):
+        self.generic_failure_message_called = True
+        return "Test Child"
+
+    def _execute(self):
+        self.execute_called = True
+        if not self._success:
+            raise CTERAException("Testing Failure")
+
+class PortalsMock():
+    def __init__(self):
+        self.browse_tenant = None
+
+    def browse(self, tenant):
+        self.browse_tenant = tenant
+
+
+class PortalMock():
+    def __init__(self):
+        self.portals = PortalsMock()
+
+class TestCteraPortalBase(BaseTest):  #pylint: disable=too-many-public-methods
+
+    def setUp(self):
+        super().setUp()
+        self._obj_mock = mock_gateway_ansible_module(self, "ansible_collections.ctera.ctera.plugins.module_utils.ctera_portal_base.PortalAnsibleModule")
+
+    def test_run_success(self):
+        runner = CteraPortalTestChild(True)
+        runner.run()
+        self._obj_mock.ctera_portal.assert_called_once_with(login=True)
+        self.assertTrue(runner.execute_called)
+        self.assertFalse(runner.generic_failure_message_called)
+        self._obj_mock.ctera_logout.assert_called_once_with()
+        self._obj_mock.ctera_exit.assert_called_once_with()
+
+    def test_run_failure(self):
+        runner = CteraPortalTestChild(False)
+        runner.run()
+        self._obj_mock.ctera_portal.assert_called_once_with(login=True)
+        self.assertTrue(runner.execute_called)
+        self.assertTrue(runner.generic_failure_message_called)
+        self._obj_mock.ctera_logout.assert_called_once_with()
+        self._obj_mock.ctera_exit.assert_called_once_with()
+
+    def test_run_tenant(self):
+        for with_tenant in [True, False]:
+            self._test_run_tenant(with_tenant)
+
+    def _test_run_tenant(self, with_tenant):
+        self._obj_mock.ctera_logout.reset_mock()
+        self._obj_mock.ctera_exit.reset_mock()
+        portal_mock = PortalMock()
+        runner = CteraPortalTestChild(True)
+        if with_tenant:
+            runner.parameters = dict(tenant='test')
+        self._obj_mock.ctera_portal = mock.MagicMock(return_value=portal_mock)
+        runner.run()
+        self._obj_mock.ctera_portal.assert_called_once_with(login=True)
+        if with_tenant:
+            self.assertEqual(portal_mock.portals.browse_tenant, 'test')
+        else:
+            self.assertIsNone(portal_mock.portals.browse_tenant)
+        self.assertTrue(runner.execute_called)
+        self.assertFalse(runner.generic_failure_message_called)
+        self._obj_mock.ctera_logout.assert_called_once_with()
+        self._obj_mock.ctera_exit.assert_called_once_with()

--- a/tests/ut/modules/test_ctera_filer_first_user.py
+++ b/tests/ut/modules/test_ctera_filer_first_user.py
@@ -47,7 +47,7 @@ class TestCteraFilerFirstUser(BaseTest):
         username = 'admin'
         password = 'password'
         email = 'admin@example.com'
-        first_user.parameters = dict(filer_user=username, filer_password=password)
+        first_user.parameters = dict(ctera_user=username, ctera_password=password)
         if with_email:
             first_user.parameters['email'] = email
         first_user._ctera_filer.get = mock.MagicMock(return_value=munch.Munch(isfirstlogin=is_first_login))

--- a/tests/ut/modules/test_ctera_portal_cloud_folder.py
+++ b/tests/ut/modules/test_ctera_portal_cloud_folder.py
@@ -1,0 +1,143 @@
+# pylint: disable=protected-access
+
+# This code is part of Ansible, but is an independent component.
+# This particular file snippet, and this file snippet only, is licensed under the Apache License 2.0.
+# Modules you write using this snippet, which is embedded dynamically by Ansible
+# still belong to the author of the module, and may assign their own license
+# to the complete work.
+#
+# Copyright 2020, CTERA Networks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import copy
+import unittest.mock as mock
+import munch
+
+try:
+    from cterasdk import CTERAException, portal_types
+except ImportError:  # pragma: no cover
+    pass  # caught by ctera_common
+
+from ansible_collections.ctera.ctera.plugins.modules.ctera_portal_cloud_folder import CteraPortalCloudFolder
+import tests.ut.mocks.ctera_portal_base_mock as ctera_portal_base_mock
+from tests.ut.base import BaseTest
+
+
+class TestCteraPortalFolderGroup(BaseTest):
+
+    def setUp(self):
+        super().setUp()
+        ctera_portal_base_mock.mock_bases(self, CteraPortalCloudFolder)
+
+    def test__execute(self):
+        for is_present in [True, False]:
+            self._test__execute(is_present)
+
+    @staticmethod
+    def _test__execute(is_present):
+        cloud_folder = CteraPortalCloudFolder()
+        cloud_folder.parameters = dict(state='present' if is_present else 'absent')
+        cloud_folder._get_cloud_folder = mock.MagicMock(return_value=dict())
+        cloud_folder._ensure_present = mock.MagicMock()
+        cloud_folder._ensure_absent = mock.MagicMock()
+        cloud_folder._execute()
+        if is_present:
+            cloud_folder._ensure_present.assert_called_once_with(mock.ANY)
+            cloud_folder._ensure_absent.assert_not_called()
+        else:
+            cloud_folder._ensure_absent.assert_called_once_with(mock.ANY)
+            cloud_folder._ensure_present.assert_not_called()
+
+    def test_get_cloud_folder_exists(self):
+        expected_cf_dict = dict(
+            name='folder_name',
+            owner=dict(name='admin'),
+            group='group_name'
+        )
+        returned_object = munch.Munch(
+            dict(
+                name=expected_cf_dict['name'],
+                group='objs/13/portal/FoldersGroup/%s' % expected_cf_dict['group'],
+                owner='objs/12/portal/PortalUser/%s' % expected_cf_dict['owner']['name']
+            )
+        )
+        cloud_folder = CteraPortalCloudFolder()
+        cloud_folder.parameters = dict(name=expected_cf_dict['name'], owner=expected_cf_dict['owner'])
+        cloud_folder._ctera_portal.cloudfs.find = mock.MagicMock(return_value=returned_object)
+        self.assertDictEqual(expected_cf_dict, cloud_folder._get_cloud_folder())
+
+    def test__get_cloud_folder_doesnt_exist(self):
+        cloud_folder = CteraPortalCloudFolder()
+        cloud_folder.parameters = dict(
+            name='folder_name',
+            owner=dict(name='admin'),
+            group='group_name'
+        )
+        cloud_folder._ctera_portal.cloudfs.find = mock.MagicMock(side_effect=CTERAException(response=munch.Munch(code=404)))
+        self.assertIsNone(cloud_folder._get_cloud_folder())
+
+    def test_ensure_present(self):
+        for is_present in [True, False]:
+            for change_attributes in [True, False]:
+                self._test_ensure_present(is_present, change_attributes)
+
+    @staticmethod
+    def _test_ensure_present(is_present, change_attributes):
+        current_attributes = dict(
+            name='folder_name',
+            owner=dict(name='admin'),
+            group='group_name',
+            winacls=True
+        )
+        desired_attributes = copy.deepcopy(current_attributes)
+        if change_attributes:
+            desired_attributes['owner']['name'] = 'Tester'
+        cloud_folder = CteraPortalCloudFolder()
+        cloud_folder.parameters = desired_attributes
+        cloud_folder._ensure_present(current_attributes if is_present else None)
+        if is_present:
+            cloud_folder._ctera_portal.cloudfs.mkdir.assert_not_called()
+        else:
+            cloud_folder._ctera_portal.cloudfs.mkdir.assert_called_with(
+                desired_attributes['name'],
+                desired_attributes['group'],
+                portal_types.UserAccount(desired_attributes['owner']['name']),
+                winacls=True
+            )
+
+    def test_ensure_absent(self):
+        for is_present in [True, False]:
+            self._test_ensure_absent(is_present)
+
+    @staticmethod
+    def _test_ensure_absent(is_present):
+        parameters = dict(
+            name='folder_name',
+            owner=dict(name='admin'),
+            group='group_name',
+            winacls=True
+        )
+        cloud_folder = CteraPortalCloudFolder()
+        cloud_folder.parameters = parameters
+        cloud_folder._ensure_absent(cloud_folder.parameters if is_present else None)
+        if is_present:
+            cloud_folder._ctera_portal.cloudfs.delete.assert_called_once_with(
+                parameters['name'],
+                portal_types.UserAccount(parameters['owner']['name']),
+            )
+        else:
+            cloud_folder._ctera_portal.cloudfs.delete.assert_not_called()

--- a/tests/ut/modules/test_ctera_portal_folder_group.py
+++ b/tests/ut/modules/test_ctera_portal_folder_group.py
@@ -1,0 +1,125 @@
+# pylint: disable=protected-access
+
+# This code is part of Ansible, but is an independent component.
+# This particular file snippet, and this file snippet only, is licensed under the Apache License 2.0.
+# Modules you write using this snippet, which is embedded dynamically by Ansible
+# still belong to the author of the module, and may assign their own license
+# to the complete work.
+#
+# Copyright 2020, CTERA Networks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import copy
+import unittest.mock as mock
+import munch
+
+try:
+    from cterasdk import CTERAException, portal_types
+except ImportError:  # pragma: no cover
+    pass  # caught by ctera_common
+
+from ansible_collections.ctera.ctera.plugins.modules.ctera_portal_folder_group import CteraPortalFolderGroup
+import tests.ut.mocks.ctera_portal_base_mock as ctera_portal_base_mock
+from tests.ut.base import BaseTest
+
+
+class TestCteraPortalFolderGroup(BaseTest):
+
+    def setUp(self):
+        super().setUp()
+        ctera_portal_base_mock.mock_bases(self, CteraPortalFolderGroup)
+
+    def test__execute(self):
+        for is_present in [True, False]:
+            self._test__execute(is_present)
+
+    @staticmethod
+    def _test__execute(is_present):
+        folder_group = CteraPortalFolderGroup()
+        folder_group.parameters = dict(state='present' if is_present else 'absent')
+        folder_group._get_folder_group = mock.MagicMock(return_value=dict())
+        folder_group._ensure_present = mock.MagicMock()
+        folder_group._ensure_absent = mock.MagicMock()
+        folder_group._execute()
+        if is_present:
+            folder_group._ensure_present.assert_called_once_with(mock.ANY)
+            folder_group._ensure_absent.assert_not_called()
+        else:
+            folder_group._ensure_absent.assert_called_once_with(mock.ANY)
+            folder_group._ensure_present.assert_not_called()
+
+    def test_get_folder_group_exists(self):
+        expected_fg_dict = dict(
+            name='fg_name',
+            owner=dict(name='admin')
+        )
+        returned_object = munch.Munch(
+            dict(
+                name=expected_fg_dict['name'],
+                owner='objs/12/portal/PortalUser/%s' % expected_fg_dict['owner']['name']
+            )
+        )
+        folder_group = CteraPortalFolderGroup()
+        folder_group.parameters = dict(name=expected_fg_dict['name'])
+        folder_group._ctera_portal.cloudfs.get = mock.MagicMock(return_value=returned_object)
+        self.assertDictEqual(expected_fg_dict, folder_group._get_folder_group())
+
+    def test__get_folder_group_doesnt_exist(self):
+        folder_group = CteraPortalFolderGroup()
+        folder_group.parameters = dict(name='admin')
+        folder_group._ctera_portal.cloudfs.get = mock.MagicMock(side_effect=CTERAException(response=munch.Munch(code=404)))
+        self.assertIsNone(folder_group._get_folder_group())
+
+    def test_ensure_present(self):
+        for is_present in [True, False]:
+            for change_attributes in [True, False]:
+                self._test_ensure_present(is_present, change_attributes)
+
+    @staticmethod
+    def _test_ensure_present(is_present, change_attributes):
+        current_attributes = dict(
+            name='fg_name',
+            owner=dict(name='admin')
+        )
+        desired_attributes = copy.deepcopy(current_attributes)
+        if change_attributes:
+            desired_attributes['owner']['name'] = 'Tester'
+        folder_group = CteraPortalFolderGroup()
+        folder_group.parameters = desired_attributes
+        folder_group._ensure_present(current_attributes if is_present else None)
+        if is_present:
+            folder_group._ctera_portal.cloudfs.mkfg.assert_not_called()
+        else:
+            folder_group._ctera_portal.cloudfs.mkfg.assert_called_with(
+                desired_attributes['name'],
+                user=portal_types.UserAccount(desired_attributes['owner']['name'])
+            )
+
+    def test_ensure_absent(self):
+        for is_present in [True, False]:
+            self._test_ensure_absent(is_present)
+
+    @staticmethod
+    def _test_ensure_absent(is_present):
+        name = 'main'
+        folder_group = CteraPortalFolderGroup()
+        folder_group.parameters = dict(name=name)
+        folder_group._ensure_absent(folder_group.parameters if is_present else None)
+        if is_present:
+            folder_group._ctera_portal.cloudfs.rmfg.assert_called_once_with(name)
+        else:
+            folder_group._ctera_portal.cloudfs.rmfg.assert_not_called()

--- a/tests/ut/modules/test_ctera_portal_init_application_server.py
+++ b/tests/ut/modules/test_ctera_portal_init_application_server.py
@@ -1,0 +1,86 @@
+# pylint: disable=protected-access
+
+# This code is part of Ansible, but is an independent component.
+# This particular file snippet, and this file snippet only, is licensed under the Apache License 2.0.
+# Modules you write using this snippet, which is embedded dynamically by Ansible
+# still belong to the author of the module, and may assign their own license
+# to the complete work.
+#
+# Copyright 2020, CTERA Networks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import copy
+import unittest.mock as mock
+import munch
+
+try:
+    from cterasdk import portal_enum
+except ImportError:  # pragma: no cover
+    pass  # caught by ctera_common
+
+
+from ansible_collections.ctera.ctera.plugins.modules.ctera_portal_init_application_server import CteraPortalInitApplication
+import tests.ut.mocks.ctera_portal_base_mock as ctera_portal_base_mock
+from tests.ut.base import BaseTest
+
+
+class TestCteraPortalLocalUser(BaseTest):
+
+    def setUp(self):
+        super().setUp()
+        ctera_portal_base_mock.mock_bases(self, CteraPortalInitApplication)
+
+    def test__execute(self):
+        for is_configured in [True, False]:
+            self._test__execute(is_configured)
+
+    @staticmethod
+    def _test__execute(is_configured):
+        init_master = CteraPortalInitApplication()
+        init_master._is_already_configured = mock.MagicMock(return_value=is_configured)
+        init_master._configure_application_server = mock.MagicMock()
+        init_master._execute()
+        if is_configured:
+            init_master._configure_application_server.assert_not_called()
+        else:
+            init_master._configure_application_server.assert_called_once_with()
+
+    def test__is_already_configured(self):
+        for wizard_state in [v for k, v in portal_enum.SetupWizardStage.__dict__.items() if not k.startswith('_')]:
+            self._test__is_already_configured(wizard_state)
+
+    def _test__is_already_configured(self, wizard_state):
+        init_master = CteraPortalInitApplication()
+        init_master._ctera_portal.setup.get_setup_status = mock.MagicMock(return_value=munch.Munch(dict(wizard=wizard_state)))
+        is_configured = init_master._is_already_configured()
+        init_master._ctera_portal.setup.get_setup_status.assert_called_once_with()
+        self.assertEqual(is_configured, wizard_state == portal_enum.SetupWizardStage.Finish)
+
+    @staticmethod
+    def test__configure_application_server():
+        parameters = dict(
+            ctera_host="192.168.1.2",
+            ipaddr="192.168.1.1",
+            secret="BestSecr3tEver"
+        )
+        create_params = copy.deepcopy(parameters)
+        create_params.pop('ctera_host')
+        init_master = CteraPortalInitApplication()
+        init_master.parameters = parameters
+        init_master._ctera_portal.setup.init_application_server = mock.MagicMock()
+        init_master._configure_application_server()
+        init_master._ctera_portal.setup.init_application_server.assert_called_once_with(**create_params)

--- a/tests/ut/modules/test_ctera_portal_init_master.py
+++ b/tests/ut/modules/test_ctera_portal_init_master.py
@@ -1,0 +1,91 @@
+# pylint: disable=protected-access
+
+# This code is part of Ansible, but is an independent component.
+# This particular file snippet, and this file snippet only, is licensed under the Apache License 2.0.
+# Modules you write using this snippet, which is embedded dynamically by Ansible
+# still belong to the author of the module, and may assign their own license
+# to the complete work.
+#
+# Copyright 2020, CTERA Networks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import copy
+import unittest.mock as mock
+import munch
+
+try:
+    from cterasdk import portal_enum
+except ImportError:  # pragma: no cover
+    pass  # caught by ctera_common
+
+from ansible_collections.ctera.ctera.plugins.modules.ctera_portal_init_master import CteraPortalInitMaster
+import tests.ut.mocks.ctera_portal_base_mock as ctera_portal_base_mock
+from tests.ut.base import BaseTest
+
+
+class TestCteraPortalLocalUser(BaseTest):
+
+    def setUp(self):
+        super().setUp()
+        ctera_portal_base_mock.mock_bases(self, CteraPortalInitMaster)
+
+    def test__execute(self):
+        for is_configured in [True, False]:
+            self._test__execute(is_configured)
+
+    @staticmethod
+    def _test__execute(is_configured):
+        init_master = CteraPortalInitMaster()
+        init_master._is_already_configured = mock.MagicMock(return_value=is_configured)
+        init_master._configure_master = mock.MagicMock()
+        init_master._execute()
+        if is_configured:
+            init_master._configure_master.assert_not_called()
+        else:
+            init_master._configure_master.assert_called_once_with()
+
+    def test__is_already_configured(self):
+        for wizard_state in [v for k, v in portal_enum.SetupWizardStage.__dict__.items() if not k.startswith('_')]:
+            self._test__is_already_configured(wizard_state)
+
+    def _test__is_already_configured(self, wizard_state):
+        init_master = CteraPortalInitMaster()
+        init_master._ctera_portal.setup.get_setup_status = mock.MagicMock(return_value=munch.Munch(dict(wizard=wizard_state)))
+        is_configured = init_master._is_already_configured()
+        init_master._ctera_portal.setup.get_setup_status.assert_called_once_with()
+        self.assertEqual(is_configured, wizard_state == portal_enum.SetupWizardStage.Finish)
+
+    @staticmethod
+    def test__configure_master():
+        parameters = dict(
+            ctera_host="192.168.1.1",
+            ctera_user='admin',
+            email='admin@example.com',
+            first_name='Admin',
+            last_name='Adminson',
+            ctera_password='password',
+            domain="ctera.me",
+        )
+        create_params = copy.deepcopy(parameters)
+        create_params.pop('ctera_host')
+        create_params['name'] = create_params.pop('ctera_user')
+        create_params['password'] = create_params.pop('ctera_password')
+        init_master = CteraPortalInitMaster()
+        init_master.parameters = parameters
+        init_master._ctera_portal.setup.init_master = mock.MagicMock()
+        init_master._configure_master()
+        init_master._ctera_portal.setup.init_master.assert_called_once_with(**create_params)

--- a/tests/ut/modules/test_ctera_portal_local_user.py
+++ b/tests/ut/modules/test_ctera_portal_local_user.py
@@ -1,0 +1,160 @@
+# pylint: disable=protected-access
+
+# This code is part of Ansible, but is an independent component.
+# This particular file snippet, and this file snippet only, is licensed under the Apache License 2.0.
+# Modules you write using this snippet, which is embedded dynamically by Ansible
+# still belong to the author of the module, and may assign their own license
+# to the complete work.
+#
+# Copyright 2020, CTERA Networks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import copy
+import datetime
+import unittest.mock as mock
+import munch
+
+try:
+    from cterasdk import CTERAException, portal_types
+except ImportError:  # pragma: no cover
+    pass  # caught by ctera_common
+
+import ansible_collections.ctera.ctera.plugins.modules.ctera_portal_local_user as ctera_portal_local_user
+import tests.ut.mocks.ctera_portal_base_mock as ctera_portal_base_mock
+from tests.ut.base import BaseTest
+
+
+class TestCteraPortalLocalUser(BaseTest):
+
+    def setUp(self):
+        super().setUp()
+        ctera_portal_base_mock.mock_bases(self, ctera_portal_local_user.CteraPortalLocalUser)
+
+    def test__execute(self):
+        for is_present in [True, False]:
+            self._test__execute(is_present)
+
+    @staticmethod
+    def _test__execute(is_present):
+        user = ctera_portal_local_user.CteraPortalLocalUser()
+        user.parameters = dict(state='present' if is_present else 'absent')
+        user._get_user = mock.MagicMock(return_value=dict())
+        user._ensure_present = mock.MagicMock()
+        user._ensure_absent = mock.MagicMock()
+        user._execute()
+        if is_present:
+            user._ensure_present.assert_called_once_with(mock.ANY)
+            user._ensure_absent.assert_not_called()
+        else:
+            user._ensure_absent.assert_called_once_with(mock.ANY)
+            user._ensure_present.assert_not_called()
+
+    def test_get_user_exists(self):
+        expected_user_dict = dict(
+            name='admin',
+            password='password',
+            first_name='Admin',
+            last_name='Adminson',
+            email='admin@example.com',
+            company="Admins",
+            role="ReadWriteAdmin",
+            comment="Important",
+            password_change=None
+        )
+        user = ctera_portal_local_user.CteraPortalLocalUser()
+        user.parameters = dict(name='admin')
+        user._ctera_portal.users.get = mock.MagicMock(return_value=munch.Munch(expected_user_dict))
+        self.assertDictEqual(expected_user_dict, user._get_user())
+
+    def test__get_user_doesnt_exist(self):
+        user = ctera_portal_local_user.CteraPortalLocalUser()
+        user.parameters = dict(name='admin')
+        user._ctera_portal.users.get = mock.MagicMock(side_effect=CTERAException(response=munch.Munch(code=404)))
+        self.assertIsNone(user._get_user())
+
+    def test_ensure_present(self):
+        for is_present in [True, False]:
+            for change_attributes in [True, False]:
+                self._test_ensure_present(is_present, change_attributes)
+
+    @staticmethod
+    def _test_ensure_present(is_present, change_attributes):
+        current_attributes = dict(
+            name='admin',
+            password='password',
+            update_password=False,
+            first_name='Admin',
+            last_name='Adminson',
+            email='admin@example.com',
+            company="Admins",
+            role="ReadWriteAdmin",
+            comment="Important",
+            password_change=None
+        )
+        desired_attributes = copy.deepcopy(current_attributes)
+        if change_attributes:
+            desired_attributes['first_name'] = 'Administrator'
+        user = ctera_portal_local_user.CteraPortalLocalUser()
+        user.parameters = desired_attributes
+        user._ensure_present(current_attributes if is_present else None)
+        if is_present:
+            if change_attributes:
+                user._ctera_portal.users.modify.assert_called_with(desired_attributes['name'], first_name=desired_attributes['first_name'])
+            else:
+                user._ctera_portal.users.modify.assert_not_called()
+        else:
+            user._ctera_portal.users.add.assert_called_with(**desired_attributes)
+
+    def test_create_no_password(self):
+        user = ctera_portal_local_user.CteraPortalLocalUser()
+        user.parameters = dict(
+            name='admin',
+            first_name='Admin',
+            last_name='Adminson',
+            email='admin@example.com',
+            password_change=None,
+            update_password=False
+        )
+        self.assertRaises(CTERAException, user._ensure_present, None)
+
+    def test_ensure_absent(self):
+        for is_present in [True, False]:
+            self._test_ensure_absent(is_present)
+
+    @staticmethod
+    def _test_ensure_absent(is_present):
+        name = 'admin'
+        user = ctera_portal_local_user.CteraPortalLocalUser()
+        user.parameters = dict(name=name)
+        user._ensure_absent(user.parameters if is_present else None)
+        if is_present:
+            user._ctera_portal.users.delete.assert_called_once_with(portal_types.UserAccount(name))
+        else:
+            user._ctera_portal.users.delete.assert_not_called()
+
+    def test__translate_password_change_same(self):
+        for value in [True, False, 5]:
+            self._test__translate_password_change_same(value)
+
+    def _test__translate_password_change_same(self, value):
+        new_value = ctera_portal_local_user.CteraPortalLocalUser._translate_password_change(value)
+        self.assertEqual(value, new_value)
+
+    def test__translate_password_change_string(self):
+        today = datetime.date.today()
+        datevalue = ctera_portal_local_user.CteraPortalLocalUser._translate_password_change(today.strftime('%Y-%m-%d'))
+        self.assertEqual(today, datevalue)

--- a/tests/ut/modules/test_ctera_portal_plan.py
+++ b/tests/ut/modules/test_ctera_portal_plan.py
@@ -1,0 +1,190 @@
+# pylint: disable=protected-access
+
+# This code is part of Ansible, but is an independent component.
+# This particular file snippet, and this file snippet only, is licensed under the Apache License 2.0.
+# Modules you write using this snippet, which is embedded dynamically by Ansible
+# still belong to the author of the module, and may assign their own license
+# to the complete work.
+#
+# Copyright 2020, CTERA Networks
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import copy
+import unittest.mock as mock
+import munch
+
+try:
+    from cterasdk import CTERAException
+except ImportError:  # pragma: no cover
+    pass  # caught by ctera_common
+
+from ansible_collections.ctera.ctera.plugins.modules.ctera_portal_plan import CteraPortalPlan
+import tests.ut.mocks.ctera_portal_base_mock as ctera_portal_base_mock
+from tests.ut.base import BaseTest
+
+
+class TestCteraPortalPlan(BaseTest):
+
+    def setUp(self):
+        super().setUp()
+        ctera_portal_base_mock.mock_bases(self, CteraPortalPlan)
+
+    def test__execute(self):
+        for is_present in [True, False]:
+            self._test__execute(is_present)
+
+    @staticmethod
+    def _test__execute(is_present):
+        plan = CteraPortalPlan()
+        plan.parameters = dict(state='present' if is_present else 'absent')
+        plan._get_plan = mock.MagicMock(return_value=dict())
+        plan._ensure_present = mock.MagicMock()
+        plan._ensure_absent = mock.MagicMock()
+        plan._execute()
+        if is_present:
+            plan._ensure_present.assert_called_once_with(mock.ANY)
+            plan._ensure_absent.assert_not_called()
+        else:
+            plan._ensure_absent.assert_called_once_with(mock.ANY)
+            plan._ensure_present.assert_not_called()
+
+    def test_get_user_exists(self):
+        expected_user_dict = dict(
+            name='main',
+            retention=[
+                dict(policy_name='retainAll', duration=11),
+                dict(policy_name='hourly', duration=12),
+                dict(policy_name='daily', duration=13),
+                dict(policy_name='weekly', duration=14),
+                dict(policy_name='monthly', duration=15),
+                dict(policy_name='quarterly', duration=16),
+                dict(policy_name='yearly', duration=17),
+                dict(policy_name='retainDeleted', duration=18)
+            ],
+            quotas=[
+                dict(item_name='EV4', amount=21),
+                dict(item_name='EV8', amount=22),
+                dict(item_name='EV16', amount=23),
+                dict(item_name='EV64', amount=24),
+                dict(item_name='EV128', amount=25),
+                dict(item_name='WA', amount=26),
+                dict(item_name='SA', amount=27),
+                dict(item_name='Share', amount=28),
+                dict(item_name='Connect', amount=29)
+            ]
+        )
+        returned_dict = munch.Munch(dict(
+            name='main',
+            retentionPolicy=munch.Munch(dict(
+                retainAll=11,
+                hourly=12,
+                daily=13,
+                weekly=14,
+                monthly=15,
+                quarterly=16,
+                yearly=17,
+                retainDeleted=18
+            )),
+            vGateways4=munch.Munch(dict(amount=21)),
+            vGateways8=munch.Munch(dict(amount=22)),
+            appliances=munch.Munch(dict(amount=23)),
+            vGateways64=munch.Munch(dict(amount=24)),
+            vGateways128=munch.Munch(dict(amount=25)),
+            workstationAgents=munch.Munch(dict(amount=26)),
+            serverAgents=munch.Munch(dict(amount=27)),
+            cloudDrives=munch.Munch(dict(amount=28)),
+            cloudDrivesLite=munch.Munch(dict(amount=29))
+        ))
+        plan = CteraPortalPlan()
+        plan.parameters = dict(name='admin')
+        plan._ctera_portal.plans.get = mock.MagicMock(return_value=munch.Munch(returned_dict))
+        self.assertDictEqual(expected_user_dict, plan._get_plan())
+
+    def test__get_user_doesnt_exist(self):
+        plan = CteraPortalPlan()
+        plan.parameters = dict(name='admin')
+        plan._ctera_portal.plans.get = mock.MagicMock(side_effect=CTERAException(response=munch.Munch(code=404)))
+        self.assertIsNone(plan._get_plan())
+
+    def test_ensure_present(self):
+        for is_present in [True, False]:
+            for change_attributes in [True, False]:
+                self._test_ensure_present(is_present, change_attributes)
+
+    @staticmethod
+    def _test_ensure_present(is_present, change_attributes):
+        current_attributes = dict(
+            name='main',
+            retention=[
+                dict(policy_name='retainAll', duration=11),
+                dict(policy_name='hourly', duration=12),
+                dict(policy_name='daily', duration=13),
+                dict(policy_name='weekly', duration=14),
+                dict(policy_name='monthly', duration=15),
+                dict(policy_name='quarterly', duration=16),
+                dict(policy_name='yearly', duration=17),
+                dict(policy_name='retainDeleted', duration=18)
+            ],
+            quotas=[
+                dict(item_name='EV4', amount=21),
+                dict(item_name='EV8', amount=22),
+                dict(item_name='EV16', amount=23),
+                dict(item_name='EV64', amount=24),
+                dict(item_name='EV128', amount=25),
+                dict(item_name='WA', amount=26),
+                dict(item_name='SA', amount=27),
+                dict(item_name='Share', amount=28),
+                dict(item_name='Connect', amount=29)
+            ]
+        )
+        desired_attributes = copy.deepcopy(current_attributes)
+        if not is_present:
+            expected_params = dict(
+                retention={i['policy_name']: i['duration'] for i in desired_attributes['retention']},
+                quotas={i['item_name']: i['amount'] for i in desired_attributes['quotas']}
+            )
+        elif change_attributes:
+            desired_attributes['retention'][0]['duration'] = 45
+            expected_params = dict(
+                retention={i['policy_name']: i['duration'] for i in desired_attributes['retention']},
+                quotas=None
+            )
+        plan = CteraPortalPlan()
+        plan.parameters = desired_attributes
+        plan._ensure_present(current_attributes if is_present else None)
+        if is_present:
+            if change_attributes:
+                plan._ctera_portal.plans.modify.assert_called_with(desired_attributes['name'], **expected_params)
+            else:
+                plan._ctera_portal.plans.modify.assert_not_called()
+        else:
+            plan._ctera_portal.plans.add.assert_called_with(desired_attributes['name'], **expected_params)
+
+    def test_ensure_absent(self):
+        for is_present in [True, False]:
+            self._test_ensure_absent(is_present)
+
+    @staticmethod
+    def _test_ensure_absent(is_present):
+        name = 'main'
+        plan = CteraPortalPlan()
+        plan.parameters = dict(name=name)
+        plan._ensure_absent(plan.parameters if is_present else None)
+        if is_present:
+            plan._ctera_portal.plans.delete.assert_called_once_with(name)
+        else:
+            plan._ctera_portal.plans.delete.assert_not_called()

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,6 @@
 [tox]
 skipsdist = True
 envlist = sanity,unittests
-indexserver =
-    TEST = https://test.pypi.org/simple/
 
 [testenv]
 install_command = pip install --pre --extra-index-url={env:extra_index_url:https://pypi.python.org/simple} {opts} {packages}
@@ -13,7 +11,7 @@ passenv =
     HOME
 deps=
     ansible
-    :TEST:cterasdk
+    cterasdk
 whitelist_externals=
     ansible-test
 commands =
@@ -22,7 +20,7 @@ commands =
 [testenv:unittests]
 deps=
     ansible
-    :TEST:cterasdk
+    cterasdk
     nose2==0.6.5
     cov-core==1.15.0
     munch
@@ -45,7 +43,7 @@ setenv =
     ANSIBLE_COLLECTIONS_PATHS=.
 deps =
     ansible
-    :TEST:cterasdk
+    cterasdk
 whitelist_externals=
     ansible-playbook
 commands =


### PR DESCRIPTION
API Change
----------
Generalize the base module to reuse for Portal
Rename filer_* to ctera_*

Portal Modules
--------------
Add generic elements for Portal Management
Add support for Master initialization
Add support for Application Server initialization
Add support for Local User Management
Add support for Plan Management
Add support for Folder Group Management
Add support for Cloud Folder Management

Configuration
--------------
Reset ssl to Consent if Trust wasnt set

Build
-----
tox - get ctera official release