### PR TITLE
Fix warnings and errors shown only in deployment

### DIFF
--- a/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_array.py
+++ b/ansible_collections/ctera/ctera/plugins/modules/ctera_filer_array.py
@@ -81,7 +81,6 @@ members:
   sample: array
 '''
 
-import ansible_collections.ctera.ctera.plugins.module_utils.ctera_common as ctera_common
 from ansible_collections.ctera.ctera.plugins.module_utils.ctera_filer_base import CteraFilerBase
 
 try:

--- a/ansible_collections/ctera/ctera/plugins/modules/ctera_portal_certificate.py
+++ b/ansible_collections/ctera/ctera/plugins/modules/ctera_portal_certificate.py
@@ -65,11 +65,9 @@ EXAMPLES = '''
 
 RETURN = r''' # '''
 
-import ansible_collections.ctera.ctera.plugins.module_utils.ctera_common as ctera_common
 from ansible_collections.ctera.ctera.plugins.module_utils.ctera_portal_base import CteraPortalBase
 
 try:
-    from cterasdk import CTERAException
     from cterasdk.lib import X509Certificate
 except ImportError:  # pragma: no cover
     pass  # caught by ctera_common

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,0 +1,1 @@
+requires_ansible: ">=2.8"


### PR DESCRIPTION
Deployment failed due to a missing file: runtime.yml inside the meta directory.
In addition, remove unused imports